### PR TITLE
skip triangular solve CPU tests on windows

### DIFF
--- a/tests/test_sparse_solve.py
+++ b/tests/test_sparse_solve.py
@@ -1,6 +1,7 @@
 import torch
 import unittest
 from random import randrange
+from sys import platform
 from torchsparsegradutils import sparse_triangular_solve
 
 
@@ -30,6 +31,8 @@ class SparseTriangularSolveTest(unittest.TestCase):
         # The device can be specialised by a daughter class
         if not hasattr(self, "device"):
             self.device = torch.device("cpu")
+            if platform == "win32":
+                self.skipTest(f"Skipping {self.__class__.__name__} CPU test as solver not implemented for Windows OS")
         self.RTOL = 1e-3
         self.unitriangular = False
         self.A_shape = (16, 16)  # square matrix
@@ -229,6 +232,8 @@ class SparseUnitTriangularSolveTest(SparseTriangularSolveTest):
     def setUp(self) -> None:
         if not hasattr(self, "device"):
             self.device = torch.device("cpu")
+            if platform == "win32":
+                self.skipTest(f"Skipping {self.__class__.__name__} CPU test as solver not implemented for Windows OS")
         self.RTOL = 1e-3
         self.unitriangular = True
         self.A_shape = (16, 16)  # square matrix


### PR DESCRIPTION
Unit tests for sparse triangular solver on CPU are skipped for Windows OS, solving: #14 

Tests confirmed to still run and all pass on WSL