### PR TITLE
35 generating random sparse matrices

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,3 +2,4 @@ torch>=1.13.0
 numpy
 scipy
 jax[cpu]
+parameterized

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -4,6 +4,8 @@ import torch
 from torchsparsegradutils.utils.random_sparse import (
     generate_random_sparse_coo_matrix, 
     generate_random_sparse_csr_matrix,
+    generate_random_sparse_strictly_triangular_coo_matrix,
+    generate_random_sparse_strictly_triangular_csr_matrix,
     )
 
 
@@ -168,4 +170,238 @@ class TestGenRandomCSR(unittest.TestCase):
         A = generate_random_sparse_csr_matrix(size, nnz, device=self.device)
         # NOTE: CSR tensors return ._nnz() per batch element
         self.assertEqual(A._nnz(), nnz)
-            
+
+# Strictly triangular tests:
+
+@parameterized_class(('name', 'device',), [
+    ("Lower_CPU", torch.device("cpu")),
+    ("CUDA", torch.device("cuda")),
+])
+class TestGenRandomStrictlyTriCOO(unittest.TestCase):
+    def setUp(self) -> None:
+        if not torch.cuda.is_available() and self.device == torch.device("cuda"):
+            self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
+        
+    # error handling:
+    def test_too_few_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([16]), 6)
+                
+    def test_too_many_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4, 8, 8]), 12)
+
+    def test_too_many_nnz(self):
+        with self.assertRaises(ValueError):
+            limit = 4 * (4 - 1) // 2
+            generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), limit + 1)
+    
+    
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+        ("int32", torch.int32),
+    ])
+    def test_incompatible_indices_dtype(self, _, indices_dtype):
+        with self.assertWarns(UserWarning):
+            generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
+    
+    # basic properties:        
+    def test_device(self):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, device=self.device)
+        self.assertEqual(A.device.type, self.device.type)
+    
+    
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+        ("int32", torch.int32),
+        ("int64", torch.int64),
+    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+    def test_indices_dtype(self, _, indices_dtype):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device)
+        self.assertEqual(A.indices().dtype, torch.int64)
+        
+    
+    @parameterized.expand([
+        ("float16", torch.float16),
+        ("float32", torch.float32),
+        ("float64", torch.float64),
+    ])
+    def test_values_dtype(self, _, values_dtype):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device)
+        self.assertEqual(A.values().dtype, values_dtype)
+    
+    # specific properties:
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 4),
+        ("2x4x4", torch.Size([2, 4, 4]), 4),
+        ("8x8", torch.Size([8, 8]), 28),
+        ("4x8x8", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_size_upper(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=True, device=self.device)
+        self.assertEqual(A.size(), size)
+        
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 4),
+        ("2x4x4", torch.Size([2, 4, 4]), 4),
+        ("8x8", torch.Size([8, 8]), 28),
+        ("4x8x8", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_size_lower(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=False, device=self.device)
+        self.assertEqual(A.size(), size)
+    
+    
+    @parameterized.expand([
+        ("4x4_12nnz", torch.Size([4, 4]), 5),
+        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+        ("8x8_22nnz", torch.Size([8, 8]), 22),
+        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_nnz_upper(self, _, size, nnz):
+        # NOTE: COO tensors return ._nnz() over all batch elements
+        A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=True, device=self.device)
+        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
+        
+        
+    @parameterized.expand([
+        ("4x4_12nnz", torch.Size([4, 4]), 5),
+        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+        ("8x8_22nnz", torch.Size([8, 8]), 22),
+        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_nnz_lower(self, _, size, nnz):
+        # NOTE: COO tensors return ._nnz() over all batch elements
+        A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=False, device=self.device)
+        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
+    
+    
+    def test_is_strictly_lower(self):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        Ad = A.to_dense()
+        self.assertTrue(torch.equal(Ad, Ad.tril(-1)))
+        
+    def test_is_strictly_upper(self):
+        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        Ad = A.to_dense()
+        self.assertTrue(torch.equal(Ad, Ad.tril(1)))
+        
+        
+@parameterized_class(('name', 'device',), [
+    ("CPU", torch.device("cpu")),
+    ("CUDA", torch.device("cuda"),),
+])
+class TestGenRandomStrictlyTriCSR(unittest.TestCase):
+    def setUp(self) -> None:
+        if not torch.cuda.is_available() and self.device == torch.device("cuda"):
+            self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
+        
+    # error handling:
+    def test_too_few_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([16]), 6)
+                
+    def test_too_many_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4, 8, 8]), 12)
+
+    def test_too_many_nnz(self):
+        with self.assertRaises(ValueError):
+            limit = 4 * (4 - 1) // 2
+            generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), limit + 1)
+    
+    
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+        ("int32", torch.int32),
+    ])
+    def test_incompatible_indices_dtype(self, _, indices_dtype):
+        with self.assertWarns(UserWarning):
+            generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
+    
+    # basic properties:        
+    def test_device(self):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, device=self.device)
+        self.assertEqual(A.device.type, self.device.type)
+    
+    
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+        ("int32", torch.int32),
+        ("int64", torch.int64),
+    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+    def test_indices_dtype(self, _, indices_dtype):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device)
+        self.assertEqual(A.crow_indices().dtype, indices_dtype)
+        self.assertEqual(A.col_indices().dtype, indices_dtype)
+        
+    
+    @parameterized.expand([
+        ("float16", torch.float16),
+        ("float32", torch.float32),
+        ("float64", torch.float64),
+    ])
+    def test_values_dtype(self, _, values_dtype):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device)
+        self.assertEqual(A.values().dtype, values_dtype)
+    
+    # specific properties:
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 4),
+        ("2x4x4", torch.Size([2, 4, 4]), 4),
+        ("8x8", torch.Size([8, 8]), 28),
+        ("4x8x8", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_size_upper(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=True, device=self.device)
+        self.assertEqual(A.size(), size)
+        
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 4),
+        ("2x4x4", torch.Size([2, 4, 4]), 4),
+        ("8x8", torch.Size([8, 8]), 28),
+        ("4x8x8", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_size_lower(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=False, device=self.device)
+        self.assertEqual(A.size(), size)
+    
+    
+    @parameterized.expand([
+        ("4x4_12nnz", torch.Size([4, 4]), 5),
+        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+        ("8x8_22nnz", torch.Size([8, 8]), 22),
+        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_nnz_upper(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=True, device=self.device)
+        # NOTE: CSR tensors return ._nnz() per batch element
+        self.assertEqual(A._nnz(), nnz)
+        
+        
+    @parameterized.expand([
+        ("4x4_12nnz", torch.Size([4, 4]), 5),
+        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+        ("8x8_22nnz", torch.Size([8, 8]), 22),
+        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+    ])
+    def test_nnz_lower(self, _, size, nnz):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=False, device=self.device)
+        # NOTE: CSR tensors return ._nnz() per batch element
+        self.assertEqual(A._nnz(), nnz)
+    
+        
+    def test_is_strictly_upper(self):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, upper=True, device=self.device)
+        Ad = A.to_dense()
+        self.assertTrue(torch.equal(Ad, Ad.triu(1)))
+        
+    def test_is_strictly_lower(self):
+        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        Ad = A.to_dense()
+        print(Ad)
+        self.assertTrue(torch.equal(Ad, Ad.tril(-1)))

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,160 +1,193 @@
 import unittest
+from parameterized import parameterized_class
 import torch
-from torchsparsegradutils.utils.random_sparse import gencoordinates, gencoordinates_square_strictly_tri
+from torchsparsegradutils.utils.random_sparse import (
+    generate_sparse_coo_matrix_indices, 
+    generate_sparse_csr_matrix_indices,
+    generate_sparse_coo_matrix_indices_strictly_triangular,
+    generate_sparse_csr_matrix_indices_strictly_triangular,
+    )
 
-class TestGenCoordinates(unittest.TestCase):
+
+@parameterized_class(('size', 'nnz', 'dtype'), [
+    (torch.Size([   4,  4]), 12, torch.int64),
+    (torch.Size([2, 4,  4]), 12, torch.int64),
+    (torch.Size([   8, 16]), 32, torch.int64),
+    (torch.Size([4, 8, 16]), 32, torch.int64),
+    (torch.Size([4, 8, 16]),  2, torch.int64),
+    # NOTE: int32 is not supported for COO indices
+])
+class TestGenIndicesCOO(unittest.TestCase):
     def setUp(self) -> None:
         # The device can be specialised by a daughter class
         if not hasattr(self, "device"):
             self.device = torch.device("cpu")
-            
-        self.size = torch.Size([4, 8, 16])
-        self.nnz = 32  # nnz per batch element
-        self.dtype = torch.int64
         
-        self.coo_coords_unbatched = gencoordinates(self.size[-2:], self.nnz, layout=torch.sparse_coo,
-                                                   dtype=self.dtype, device=self.device)
+        self.indices = generate_sparse_coo_matrix_indices(self.size, self.nnz, dtype=self.dtype, device=self.device)
         
-        self.coo_coords_batched = gencoordinates(self.size, self.nnz, layout=torch.sparse_coo, 
-                                                 dtype=self.dtype, device=self.device)
-        
-        self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates(self.size[-2:], self.nnz, layout=torch.sparse_csr,
-                                                    dtype=self.dtype, device=self.device)
-        
-        
-        self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates(self.size, self.nnz, layout=torch.sparse_csr,
-                                                    dtype=self.dtype, device=self.device)
-    
-    # error handling:    
-    def test_incorrect_shape(self):
+    # error handling:
+    def test_too_few_dims(self):
         with self.assertRaises(ValueError):
-            gencoordinates((1,) + self.size, self.nnz, layout=torch.sparse_coo, dtype=self.dtype, device=self.device)
-            
-    def test_incorrect_layout(self):
+            generate_sparse_coo_matrix_indices(torch.Size([1]), self.nnz, dtype=self.dtype, device=self.device)
+                
+    def test_too_many_dims(self):
         with self.assertRaises(ValueError):
-            gencoordinates(self.size, self.nnz, layout=torch.sparse_bsr, dtype=self.dtype, device=self.device)
+            if len(self.size) == 2:
+                generate_sparse_coo_matrix_indices((1, 1) + self.size, self.nnz, dtype=self.dtype, device=self.device)
+            elif len(self.size) == 3:
+                generate_sparse_coo_matrix_indices((1,) + self.size, self.nnz, dtype=self.dtype, device=self.device)
             
     def test_too_many_nnz(self):
         nnz = self.size[-2:].numel() + 1
         with self.assertRaises(ValueError):
-            gencoordinates(self.size, nnz + 1, layout=torch.sparse_coo, dtype=self.dtype, device=self.device)
+            generate_sparse_coo_matrix_indices(self.size, nnz, dtype=self.dtype, device=self.device)
     
-    # unmbacthed COO:    
-    def test_gencoords_coo_unbatched_shape(self):
-        self.assertEqual(self.coo_coords_unbatched.shape, torch.Size([2, self.nnz]))
+    # basic properties:        
+    def test_gencoords_device(self):
+        self.assertEqual(self.indices.device, self.device)
         
-    def test_gencoords_coo_unbatched_unique(self):
-        self.assertEqual(len(set([self.coo_coords_unbatched[:, i] for i in range(self.coo_coords_unbatched.shape[-1])])), self.nnz)
+    def test_gencoords_dtype(self):
+        self.assertEqual(self.indices.dtype, self.dtype)
         
-    def test_gencoords_coo_unbatched_range(self):
-        print(self.coo_coords_unbatched)
-        self.assertTrue((self.coo_coords_unbatched.t() < torch.tensor([self.size[-2], self.size[-1]])).all())
+    # specific properties:
+    def test_shape(self):
+        if len(self.size) == 2:
+            self.assertEqual(self.indices.shape, torch.Size([2, self.nnz]))
+        elif len(self.size) == 3:
+            self.assertEqual(self.indices.shape, torch.Size([3, self.nnz*self.size[0]]))
         
-    def test_gencoords_coo_unbatched_device(self):
-        self.assertEqual(self.coo_coords_unbatched.device, self.device)
-        
-    def test_gencoords_coo_unbatched_dtype(self):
-        self.assertEqual(self.coo_coords_unbatched.dtype, self.dtype)
-        
-    def test_gencoords_coo_unbatched_coords(self):
-        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        try:  
-            torch._validate_sparse_coo_tensor_args(self.coo_coords_unbatched, dummy_values, self.size[-2:])
-        except RuntimeError as e:
-            self.fail(f"Error: {e}")
+    def test_unique(self):
+        if len(self.size) == 2:
+            self.assertEqual(len(set([self.indices[:, i] for i in range(self.indices.shape[-1])])), self.nnz)
+        elif len(self.size) == 3:
+            self.assertEqual(len(set([self.indices[1:, :] for i in range(self.indices.shape[-1]//self.size[0])])), self.nnz)
             
-    def test_gencoords_coo_unbatched_coords_int32_dtype(self):
-        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.coo_coords_unbatched.to(torch.int32), dummy_values, self.size[-2:])
-
-    # batched COO:    
-    def test_gencoords_coo_batched_shape(self):
-        self.assertEqual(self.coo_coords_batched.shape, torch.Size([3, self.nnz*self.size[0]]))
-        
-    def test_gencoords_coo_batched_device(self):
-        self.assertEqual(self.coo_coords_batched.device, self.device)
-        
-    def test_gencoords_coo_batched_dtype(self):
-        self.assertEqual(self.coo_coords_batched.dtype, self.dtype)
-        
-    def test_gencoords_coo_batched_coords(self):
-        dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
-        try:  
-            torch._validate_sparse_coo_tensor_args(self.coo_coords_batched, dummy_values, self.size)
-        except RuntimeError as e:
-            self.fail(f"Error: {e}")
-             
-    def test_gencoords_coo_batched_coords_int32_dtype(self):
-        dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
-        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.coo_coords_batched.to(torch.int32), dummy_values, self.size)
+    def test_range(self):
+        if len(self.size) == 2:
+            self.assertTrue((self.indices.t() < torch.tensor([self.size[-2], self.size[-1]])).all())
+        elif len(self.size) == 3:
+            self.assertTrue((self.indices[1:, :].t() < torch.tensor([self.size[-2], self.size[-1]])).all())
             
-    # unbatched CSR:
-    def test_gencoords_csr_unbatched_shape(self):
-        self.assertEqual(self.csr_crow_indices_unbatched.shape, torch.Size([self.size[-2] + 1]))
-        self.assertEqual(self.csr_col_indices_unbatched.shape, torch.Size([self.nnz]))
-        
-    def test_gencoords_csr_unbatched_device(self):
-        self.assertEqual(self.csr_crow_indices_unbatched.device, self.device)
-        self.assertEqual(self.csr_col_indices_unbatched.device, self.device)
-        
-    def test_gencoords_csr_unbatched_dtype(self):
-        self.assertEqual(self.csr_crow_indices_unbatched.dtype, self.dtype)
-        self.assertEqual(self.csr_col_indices_unbatched.dtype, self.dtype)
-        
-    def test_gencoords_csr_unbatched_coords(self):
-        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        try:  
-            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched, dummy_values, self.size[-2:])
-        except RuntimeError as e:
-            self.fail(f"Error: {e}")
+    def test_indices(self):
+        if len(self.size) == 2:
+            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        elif len(self.size) == 3:
+            dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
             
-    def test_gencoords_csr_unbatched_coords(self):
-        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
         try:  
-            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched, dummy_values, self.size[-2:])
+            torch._validate_sparse_coo_tensor_args(self.indices, dummy_values, self.size)
         except RuntimeError as e:
-            self.fail(f"Error: {e}")
-    
-    # batched CSR:
-    def test_gencoords_csr_batched_shape(self):
-        self.assertEqual(self.csr_crow_indices_batched.shape, torch.Size([self.size[0], self.size[-2] + 1]))
-        self.assertEqual(self.csr_col_indices_batched.shape, torch.Size([self.size[0], self.nnz]))
+                self.fail(f"Error: {e}")
+            
+    def test_indices_int32(self):
+        if len(self.size) == 2:
+            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        elif len(self.size) == 3:
+            dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
+        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.indices.to(torch.int32), dummy_values, self.size)
         
-    def test_gencoords_csr_batched_device(self):
-        self.assertEqual(self.csr_crow_indices_batched.device, self.device)
-        self.assertEqual(self.csr_col_indices_batched.device, self.device)
         
-    def test_gencoords_csr_batched_dtype(self):
-        self.assertEqual(self.csr_crow_indices_batched.dtype, self.dtype)
-        self.assertEqual(self.csr_col_indices_batched.dtype, self.dtype)
-        
-    def test_gencoords_csr_batched_coords(self):
-        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device).repeat(self.size[0], 1)
-        try:  
-            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_batched, self.csr_col_indices_batched, dummy_values, self.size)
-        except RuntimeError as e:
-            self.fail(f"Error: {e}")
-    
-
-class TestGenCoordinatesTril(TestGenCoordinates):
+@parameterized_class(('size', 'nnz', 'dtype'), [
+    (torch.Size([   4,  4]), 12, torch.int64),
+    (torch.Size([2, 4,  4]), 12, torch.int64),
+    (torch.Size([   8, 16]), 32, torch.int64),
+    (torch.Size([4, 8, 16]), 32, torch.int64),
+    (torch.Size([4, 8, 16]), 32, torch.int32),  # int32 works with CSR
+    (torch.Size([4, 8, 16]),  2, torch.int64),
+])        
+class TestGenIndicesCSR(unittest.TestCase):
     def setUp(self) -> None:
         # The device can be specialised by a daughter class
         if not hasattr(self, "device"):
             self.device = torch.device("cpu")
+        
+        self.crow_indices, self.col_indices = generate_sparse_csr_matrix_indices(self.size, self.nnz, dtype=self.dtype, device=self.device)
+        
+    # error handling:
+    def test_too_few_dims(self):
+        with self.assertRaises(ValueError):
+            generate_sparse_csr_matrix_indices(torch.Size([1]), self.nnz, dtype=self.dtype, device=self.device)
+                
+    def test_too_many_dims(self):
+        with self.assertRaises(ValueError):
+            if len(self.size) == 2:
+                generate_sparse_csr_matrix_indices((1, 1) + self.size, self.nnz, dtype=self.dtype, device=self.device)
+            elif len(self.size) == 3:
+                generate_sparse_csr_matrix_indices((1,) + self.size, self.nnz, dtype=self.dtype, device=self.device)
             
-        self.size = torch.Size([4, 12, 12])
-        self.nnz = 32  # nnz per batch element
-        self.dtype = torch.int64
+    def test_too_many_nnz(self):
+        nnz = self.size[-2:].numel() + 1
+        with self.assertRaises(ValueError):
+            generate_sparse_csr_matrix_indices(self.size, nnz, dtype=self.dtype, device=self.device)
+    
+    # basic properties:        
+    def test_gencoords_device(self):
+        self.assertEqual(self.crow_indices.device, self.device)
+        self.assertEqual(self.col_indices.device, self.device)
         
-        self.coo_coords_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_coo,
-                                                   dtype=self.dtype, device=self.device)
+    def test_gencoords_dtype(self):
+        self.assertEqual(self.crow_indices.dtype, self.dtype)
+        self.assertEqual(self.col_indices.device, self.device)
         
-        self.coo_coords_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_coo, 
-                                                 dtype=self.dtype, device=self.device)
+    # specific properties:
+    def test_shape(self):
+       if len(self.size) == 2:
+            self.assertEqual(self.crow_indices.shape, torch.Size([self.size[-2] + 1]))
+            self.assertEqual(self.col_indices.shape, torch.Size([self.nnz]))
+       elif len(self.size) == 3:
+            self.assertEqual(self.crow_indices.shape, torch.Size([self.size[0], self.size[-2] + 1]))
+            self.assertEqual(self.col_indices.shape, torch.Size([self.size[0], self.nnz]))
+            
+    def test_unique(self):
+        self.skipTest("Cannot test CSR matrices for uniqueness. In other words they cannot be coalesced.")
         
-        self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_csr,
-                                                    dtype=self.dtype, device=self.device)
+    def test_range(self):
+        if len(self.size) == 2:
+            self.assertEqual(self.crow_indices[0], 0)
+            self.assertEqual(self.crow_indices[-1], self.nnz)
+            self.assertTrue((self.col_indices < torch.tensor([self.size[-1]])).all())
+        elif len(self.size) == 3:
+            self.assertEqual(self.crow_indices[0, 0], 0)
+            self.assertEqual(self.crow_indices[0, -1], self.nnz)
+            self.assertTrue((self.col_indices[0] < torch.tensor([self.size[-1]])).all())
+            
+    def test_indices(self):
+        if len(self.size) == 2:
+            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        elif len(self.size) == 3:
+            dummy_values = torch.ones(self.size[0], self.nnz, dtype=torch.float32, device=self.device)
+            
+        try:  
+            torch._validate_sparse_csr_tensor_args(self.crow_indices, self.col_indices, dummy_values, self.size)
+        except RuntimeError as e:
+                self.fail(f"Error: {e}")
+
+    
+# @parameterized_class(('size', 'nnz', 'layout', 'dtype'), [
+#     (torch.Size([   12, 12]), 32, torch.sparse_coo, torch.int64),
+#     (torch.Size([4, 12, 12]), 32, torch.sparse_coo, torch.int64),
+#     # NOTE: int32 is not supported for COO indices
+    
+#     (torch.Size([   12, 12]), 32, torch.sparse_csr, torch.int64),
+#     (torch.Size([4, 12, 12]), 32, torch.sparse_csr, torch.int64),
+#     (torch.Size([4, 12, 12]), 32, torch.sparse_csr, torch.int32),
+# ])
+# class TestGenCoordinatesTril(TestGenCoordinates):
+#     def setUp(self) -> None:
+#         super().setUp()    
+#         # self.size = torch.Size([4, 12, 12])
+#         # self.nnz = 32  # nnz per batch element
+#         self.dtype = torch.int64
+        
+#         self.coo_coords_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_coo,
+#                                                    dtype=self.dtype, device=self.device)
+        
+#         self.coo_coords_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_coo, 
+#                                                  dtype=self.dtype, device=self.device)
+        
+#         self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_csr,
+#                                                     dtype=self.dtype, device=self.device)
         
         
-        self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_csr,
-                                                    dtype=self.dtype, device=self.device)
+#         self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_csr,
+#                                                     dtype=self.dtype, device=self.device)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -316,7 +316,6 @@ class TestGenRandomStrictlyTriCSR(unittest.TestCase):
     @parameterized.expand([
         ("int08", torch.int8),
         ("int16", torch.int16),
-        ("int32", torch.int32),
     ])
     def test_incompatible_indices_dtype(self, _, indices_dtype):
         with self.assertWarns(UserWarning):

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -8,6 +8,8 @@ from torchsparsegradutils.utils.random_sparse import (
     generate_random_sparse_strictly_triangular_csr_matrix,
 )
 
+# https://pytorch.org/docs/stable/generated/torch.sparse.check_sparse_tensor_invariants.html#torch.sparse.check_sparse_tensor_invariants
+torch.sparse.check_sparse_tensor_invariants.enable()
 
 @parameterized_class(
     (
@@ -48,7 +50,7 @@ class TestGenRandomCOO(unittest.TestCase):
         ]
     )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
-        with self.assertWarns(UserWarning):
+        with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
 
     # basic properties:
@@ -58,15 +60,12 @@ class TestGenRandomCOO(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("int08", torch.int8),
-            ("int16", torch.int16),
-            ("int32", torch.int32),
             ("int64", torch.int64),
         ]
     )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
-        self.assertEqual(A.indices().dtype, torch.int64)
+        self.assertEqual(A.indices().dtype, indices_dtype)
 
     @parameterized.expand(
         [
@@ -79,6 +78,7 @@ class TestGenRandomCOO(unittest.TestCase):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
         self.assertEqual(A.values().dtype, values_dtype)
 
+    
     @parameterized.expand(
         [
             ("4x4", torch.Size([4, 4]), 12),
@@ -143,7 +143,7 @@ class TestGenRandomCSR(unittest.TestCase):
         ]
     )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
-        with self.assertWarns(UserWarning):
+        with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
 
     # basic properties:
@@ -153,12 +153,10 @@ class TestGenRandomCSR(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("int08", torch.int8),
-            ("int16", torch.int16),
             ("int32", torch.int32),
             ("int64", torch.int64),
         ]
-    )  # NOTE: All integer dtypes are supported for CSR indices, although below int32 is not recommended
+    )  # NOTE: Only int32 and int64 are supported for CSR indices
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
         self.assertEqual(A.crow_indices().dtype, indices_dtype)
@@ -241,7 +239,7 @@ class TestGenRandomStrictlyTriCOO(unittest.TestCase):
         ]
     )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
-        with self.assertWarns(UserWarning):
+        with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
 
     # basic properties:
@@ -251,9 +249,6 @@ class TestGenRandomStrictlyTriCOO(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("int08", torch.int8),
-            ("int16", torch.int16),
-            ("int32", torch.int32),
             ("int64", torch.int64),
         ]
     )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
@@ -261,7 +256,7 @@ class TestGenRandomStrictlyTriCOO(unittest.TestCase):
         A = generate_random_sparse_strictly_triangular_coo_matrix(
             torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device
         )
-        self.assertEqual(A.indices().dtype, torch.int64)
+        self.assertEqual(A.indices().dtype, indices_dtype)
 
     @parameterized.expand(
         [
@@ -381,7 +376,7 @@ class TestGenRandomStrictlyTriCSR(unittest.TestCase):
         ]
     )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
-        with self.assertWarns(UserWarning):
+        with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
 
     # basic properties:
@@ -391,12 +386,10 @@ class TestGenRandomStrictlyTriCSR(unittest.TestCase):
 
     @parameterized.expand(
         [
-            ("int08", torch.int8),
-            ("int16", torch.int16),
             ("int32", torch.int32),
             ("int64", torch.int64),
         ]
-    )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+    )
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_strictly_triangular_csr_matrix(
             torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -40,7 +40,6 @@ class TestGenRandomCOO(unittest.TestCase):
     ])
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
-        A = A.coalesce()
         self.assertEqual(A.indices().dtype, torch.int64)
         # NOTE: int32 is not supported for COO indices, it will be converted to int64
     
@@ -51,7 +50,6 @@ class TestGenRandomCOO(unittest.TestCase):
     ])
     def test_values_dtype(self, _, values_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
-        A = A.coalesce()
         self.assertEqual(A.values().dtype, values_dtype)
         
     @parameterized.expand([
@@ -62,7 +60,6 @@ class TestGenRandomCOO(unittest.TestCase):
     ])
     def test_size(self, _, size, nnz):
         A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
-        A = A.coalesce()
         self.assertEqual(A.size(), size)
     
     @parameterized.expand([
@@ -72,8 +69,78 @@ class TestGenRandomCOO(unittest.TestCase):
         ("4x8x16", torch.Size([4, 8, 16]), 32),
     ])
     def test_nnz(self, _, size, nnz):
+        # NOTE: COO tensors return ._nnz() over all batch elements
         A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
-        A = A.coalesce()
         self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
             
         
+@parameterized_class(('name', 'device',), [
+    ("CPU", torch.device("cpu")),
+    ("CUDA", torch.device("cuda"),),
+])
+class TestGenRandomCSR(unittest.TestCase):
+    def setUp(self) -> None:
+        if not torch.cuda.is_available() and self.device == torch.device("cuda"):
+            self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
+        
+    # error handling:
+    def test_too_few_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_csr_matrix(torch.Size([16]), 6)
+                
+    def test_too_many_dims(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_csr_matrix(torch.Size([4, 4, 8, 8]), 32)
+
+    def test_too_many_nnz(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_csr_matrix(torch.Size([4, 4]), 17)
+    
+    # basic properties:        
+    def test_device(self):
+        A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, device=self.device)
+        self.assertEqual(A.device.type, self.device.type)
+    
+    
+    @parameterized.expand([
+        ("int32", torch.int32),
+        ("int64", torch.int64),
+    ])
+    def test_indices_dtype(self, _, indices_dtype):
+        A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
+        self.assertEqual(A.crow_indices().dtype, indices_dtype)
+        self.assertEqual(A.col_indices().dtype, indices_dtype)
+    
+    
+    @parameterized.expand([
+        ("float16", torch.float16),
+        ("float32", torch.float32),
+        ("float64", torch.float64),
+    ])
+    def test_values_dtype(self, _, values_dtype):
+        A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
+        self.assertEqual(A.values().dtype, values_dtype)
+    
+    
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 12),
+        ("2x4x4", torch.Size([2, 4, 4]), 12),
+        ("8x16", torch.Size([8, 16]), 32),
+        ("4x8x16", torch.Size([4, 8, 16]), 32),
+    ])
+    def test_size(self, _, size, nnz):
+        A = generate_random_sparse_csr_matrix(size, nnz, device=self.device)
+        self.assertEqual(A.size(), size)
+    
+    
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 12),
+        ("2x4x4", torch.Size([2, 4, 4]), 12),
+        ("8x16", torch.Size([8, 16]), 32),
+        ("4x8x16", torch.Size([4, 8, 16]), 32),
+    ])
+    def test_nnz(self, _, size, nnz):
+        A = generate_random_sparse_csr_matrix(size, nnz, device=self.device)
+        # NOTE: CSR tensors return ._nnz() per batch element
+        self.assertEqual(A._nnz(), nnz)
+            

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -2,27 +2,36 @@ import unittest
 from parameterized import parameterized, parameterized_class
 import torch
 from torchsparsegradutils.utils.random_sparse import (
-    generate_random_sparse_coo_matrix, 
+    generate_random_sparse_coo_matrix,
     generate_random_sparse_csr_matrix,
     generate_random_sparse_strictly_triangular_coo_matrix,
     generate_random_sparse_strictly_triangular_csr_matrix,
-    )
+)
 
 
-@parameterized_class(('name', 'device',), [
-    ("CPU", torch.device("cpu")),
-    ("CUDA", torch.device("cuda"),),
-])
+@parameterized_class(
+    (
+        "name",
+        "device",
+    ),
+    [
+        ("CPU", torch.device("cpu")),
+        (
+            "CUDA",
+            torch.device("cuda"),
+        ),
+    ],
+)
 class TestGenRandomCOO(unittest.TestCase):
     def setUp(self) -> None:
         if not torch.cuda.is_available() and self.device == torch.device("cuda"):
             self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
-        
+
     # error handling:
     def test_too_few_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([16]), 6)
-                
+
     def test_too_many_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([4, 4, 8, 8]), 32)
@@ -30,81 +39,95 @@ class TestGenRandomCOO(unittest.TestCase):
     def test_too_many_nnz(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 17)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+        ]
+    )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
         with self.assertWarns(UserWarning):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
-    
-    # basic properties:        
+
+    # basic properties:
     def test_device(self):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, device=self.device)
         self.assertEqual(A.device.type, self.device.type)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-        ("int64", torch.int64),
-    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+            ("int64", torch.int64),
+        ]
+    )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
         self.assertEqual(A.indices().dtype, torch.int64)
-        
-    
-    @parameterized.expand([
-        ("float16", torch.float16),
-        ("float32", torch.float32),
-        ("float64", torch.float64),
-    ])
+
+    @parameterized.expand(
+        [
+            ("float16", torch.float16),
+            ("float32", torch.float32),
+            ("float64", torch.float64),
+        ]
+    )
     def test_values_dtype(self, _, values_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
         self.assertEqual(A.values().dtype, values_dtype)
-    
-        
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 12),
-        ("2x4x4", torch.Size([2, 4, 4]), 12),
-        ("8x16", torch.Size([8, 16]), 32),
-        ("4x8x16", torch.Size([4, 8, 16]), 32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 12),
+            ("2x4x4", torch.Size([2, 4, 4]), 12),
+            ("8x16", torch.Size([8, 16]), 32),
+            ("4x8x16", torch.Size([4, 8, 16]), 32),
+        ]
+    )
     def test_size(self, _, size, nnz):
         A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
         self.assertEqual(A.size(), size)
-    
-    
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 12),
-        ("2x4x4", torch.Size([2, 4, 4]), 12),
-        ("8x16", torch.Size([8, 16]), 32),
-        ("4x8x16", torch.Size([4, 8, 16]), 32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 12),
+            ("2x4x4", torch.Size([2, 4, 4]), 12),
+            ("8x16", torch.Size([8, 16]), 32),
+            ("4x8x16", torch.Size([4, 8, 16]), 32),
+        ]
+    )
     def test_nnz(self, _, size, nnz):
         # NOTE: COO tensors return ._nnz() over all batch elements
         A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
-        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
-            
-        
-@parameterized_class(('name', 'device',), [
-    ("CPU", torch.device("cpu")),
-    ("CUDA", torch.device("cuda"),),
-])
+        self.assertEqual(A._nnz(), nnz * ((1,) + size)[-3])
+
+
+@parameterized_class(
+    (
+        "name",
+        "device",
+    ),
+    [
+        ("CPU", torch.device("cpu")),
+        (
+            "CUDA",
+            torch.device("cuda"),
+        ),
+    ],
+)
 class TestGenRandomCSR(unittest.TestCase):
     def setUp(self) -> None:
         if not torch.cuda.is_available() and self.device == torch.device("cuda"):
             self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
-        
+
     # error handling:
     def test_too_few_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_csr_matrix(torch.Size([16]), 6)
-                
+
     def test_too_many_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_csr_matrix(torch.Size([4, 4, 8, 8]), 32)
@@ -112,81 +135,95 @@ class TestGenRandomCSR(unittest.TestCase):
     def test_too_many_nnz(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_csr_matrix(torch.Size([4, 4]), 17)
-            
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-    ])
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+        ]
+    )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
         with self.assertWarns(UserWarning):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
-    
-    # basic properties:        
+
+    # basic properties:
     def test_device(self):
         A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, device=self.device)
         self.assertEqual(A.device.type, self.device.type)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-        ("int64", torch.int64),
-    ])  # NOTE: All integer dtypes are supported for CSR indices, although below int32 is not recommended
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+            ("int64", torch.int64),
+        ]
+    )  # NOTE: All integer dtypes are supported for CSR indices, although below int32 is not recommended
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
         self.assertEqual(A.crow_indices().dtype, indices_dtype)
         self.assertEqual(A.col_indices().dtype, indices_dtype)
-    
-    
-    @parameterized.expand([
-        ("float16", torch.float16),
-        ("float32", torch.float32),
-        ("float64", torch.float64),
-    ])
+
+    @parameterized.expand(
+        [
+            ("float16", torch.float16),
+            ("float32", torch.float32),
+            ("float64", torch.float64),
+        ]
+    )
     def test_values_dtype(self, _, values_dtype):
         A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
         self.assertEqual(A.values().dtype, values_dtype)
-    
-    
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 12),
-        ("2x4x4", torch.Size([2, 4, 4]), 12),
-        ("8x16", torch.Size([8, 16]), 32),
-        ("4x8x16", torch.Size([4, 8, 16]), 32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 12),
+            ("2x4x4", torch.Size([2, 4, 4]), 12),
+            ("8x16", torch.Size([8, 16]), 32),
+            ("4x8x16", torch.Size([4, 8, 16]), 32),
+        ]
+    )
     def test_size(self, _, size, nnz):
         A = generate_random_sparse_csr_matrix(size, nnz, device=self.device)
         self.assertEqual(A.size(), size)
-    
-    
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 12),
-        ("2x4x4", torch.Size([2, 4, 4]), 12),
-        ("8x16", torch.Size([8, 16]), 32),
-        ("4x8x16", torch.Size([4, 8, 16]), 32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 12),
+            ("2x4x4", torch.Size([2, 4, 4]), 12),
+            ("8x16", torch.Size([8, 16]), 32),
+            ("4x8x16", torch.Size([4, 8, 16]), 32),
+        ]
+    )
     def test_nnz(self, _, size, nnz):
         A = generate_random_sparse_csr_matrix(size, nnz, device=self.device)
         # NOTE: CSR tensors return ._nnz() per batch element
         self.assertEqual(A._nnz(), nnz)
 
+
 # Strictly triangular tests:
 
-@parameterized_class(('name', 'device',), [
-    ("Lower_CPU", torch.device("cpu")),
-    ("CUDA", torch.device("cuda")),
-])
+
+@parameterized_class(
+    (
+        "name",
+        "device",
+    ),
+    [
+        ("Lower_CPU", torch.device("cpu")),
+        ("CUDA", torch.device("cuda")),
+    ],
+)
 class TestGenRandomStrictlyTriCOO(unittest.TestCase):
     def setUp(self) -> None:
         if not torch.cuda.is_available() and self.device == torch.device("cuda"):
             self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
-        
+
     # error handling:
     def test_too_few_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([16]), 6)
-                
+
     def test_too_many_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4, 8, 8]), 12)
@@ -195,114 +232,139 @@ class TestGenRandomStrictlyTriCOO(unittest.TestCase):
         with self.assertRaises(ValueError):
             limit = 4 * (4 - 1) // 2
             generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), limit + 1)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-    ])
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+        ]
+    )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
         with self.assertWarns(UserWarning):
             generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
-    
-    # basic properties:        
+
+    # basic properties:
     def test_device(self):
         A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, device=self.device)
         self.assertEqual(A.device.type, self.device.type)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-        ("int64", torch.int64),
-    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+            ("int64", torch.int64),
+        ]
+    )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
     def test_indices_dtype(self, _, indices_dtype):
-        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device)
+        A = generate_random_sparse_strictly_triangular_coo_matrix(
+            torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device
+        )
         self.assertEqual(A.indices().dtype, torch.int64)
-        
-    
-    @parameterized.expand([
-        ("float16", torch.float16),
-        ("float32", torch.float32),
-        ("float64", torch.float64),
-    ])
+
+    @parameterized.expand(
+        [
+            ("float16", torch.float16),
+            ("float32", torch.float32),
+            ("float64", torch.float64),
+        ]
+    )
     def test_values_dtype(self, _, values_dtype):
-        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device)
+        A = generate_random_sparse_strictly_triangular_coo_matrix(
+            torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device
+        )
         self.assertEqual(A.values().dtype, values_dtype)
-    
+
     # specific properties:
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 4),
-        ("2x4x4", torch.Size([2, 4, 4]), 4),
-        ("8x8", torch.Size([8, 8]), 28),
-        ("4x8x8", torch.Size([4, 8, 8]), 28),
-    ])
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 4),
+            ("2x4x4", torch.Size([2, 4, 4]), 4),
+            ("8x8", torch.Size([8, 8]), 28),
+            ("4x8x8", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_size_upper(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=True, device=self.device)
         self.assertEqual(A.size(), size)
-        
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 4),
-        ("2x4x4", torch.Size([2, 4, 4]), 4),
-        ("8x8", torch.Size([8, 8]), 28),
-        ("4x8x8", torch.Size([4, 8, 8]), 28),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 4),
+            ("2x4x4", torch.Size([2, 4, 4]), 4),
+            ("8x8", torch.Size([8, 8]), 28),
+            ("4x8x8", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_size_lower(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=False, device=self.device)
         self.assertEqual(A.size(), size)
-    
-    
-    @parameterized.expand([
-        ("4x4_12nnz", torch.Size([4, 4]), 5),
-        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
-        ("8x8_22nnz", torch.Size([8, 8]), 22),
-        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4_12nnz", torch.Size([4, 4]), 5),
+            ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+            ("8x8_22nnz", torch.Size([8, 8]), 22),
+            ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_nnz_upper(self, _, size, nnz):
         # NOTE: COO tensors return ._nnz() over all batch elements
         A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=True, device=self.device)
-        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
-        
-        
-    @parameterized.expand([
-        ("4x4_12nnz", torch.Size([4, 4]), 5),
-        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
-        ("8x8_22nnz", torch.Size([8, 8]), 22),
-        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
-    ])
+        self.assertEqual(A._nnz(), nnz * ((1,) + size)[-3])
+
+    @parameterized.expand(
+        [
+            ("4x4_12nnz", torch.Size([4, 4]), 5),
+            ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+            ("8x8_22nnz", torch.Size([8, 8]), 22),
+            ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_nnz_lower(self, _, size, nnz):
         # NOTE: COO tensors return ._nnz() over all batch elements
         A = generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=False, device=self.device)
-        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
-    
-    
+        self.assertEqual(A._nnz(), nnz * ((1,) + size)[-3])
+
     def test_is_strictly_lower(self):
-        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        A = generate_random_sparse_strictly_triangular_coo_matrix(
+            torch.Size([4, 4]), 5, upper=False, device=self.device
+        )
         Ad = A.to_dense()
         self.assertTrue(torch.equal(Ad, Ad.tril(-1)))
-        
+
     def test_is_strictly_upper(self):
-        A = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        A = generate_random_sparse_strictly_triangular_coo_matrix(
+            torch.Size([4, 4]), 5, upper=False, device=self.device
+        )
         Ad = A.to_dense()
         self.assertTrue(torch.equal(Ad, Ad.tril(1)))
-        
-        
-@parameterized_class(('name', 'device',), [
-    ("CPU", torch.device("cpu")),
-    ("CUDA", torch.device("cuda"),),
-])
+
+
+@parameterized_class(
+    (
+        "name",
+        "device",
+    ),
+    [
+        ("CPU", torch.device("cpu")),
+        (
+            "CUDA",
+            torch.device("cuda"),
+        ),
+    ],
+)
 class TestGenRandomStrictlyTriCSR(unittest.TestCase):
     def setUp(self) -> None:
         if not torch.cuda.is_available() and self.device == torch.device("cuda"):
             self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
-        
+
     # error handling:
     def test_too_few_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([16]), 6)
-                
+
     def test_too_many_dims(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4, 8, 8]), 12)
@@ -311,96 +373,110 @@ class TestGenRandomStrictlyTriCSR(unittest.TestCase):
         with self.assertRaises(ValueError):
             limit = 4 * (4 - 1) // 2
             generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), limit + 1)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-    ])
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+        ]
+    )
     def test_incompatible_indices_dtype(self, _, indices_dtype):
         with self.assertWarns(UserWarning):
             generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype)
-    
-    # basic properties:        
+
+    # basic properties:
     def test_device(self):
         A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, device=self.device)
         self.assertEqual(A.device.type, self.device.type)
-    
-    
-    @parameterized.expand([
-        ("int08", torch.int8),
-        ("int16", torch.int16),
-        ("int32", torch.int32),
-        ("int64", torch.int64),
-    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
+
+    @parameterized.expand(
+        [
+            ("int08", torch.int8),
+            ("int16", torch.int16),
+            ("int32", torch.int32),
+            ("int64", torch.int64),
+        ]
+    )  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
     def test_indices_dtype(self, _, indices_dtype):
-        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device)
+        A = generate_random_sparse_strictly_triangular_csr_matrix(
+            torch.Size([4, 4]), 5, indices_dtype=indices_dtype, device=self.device
+        )
         self.assertEqual(A.crow_indices().dtype, indices_dtype)
         self.assertEqual(A.col_indices().dtype, indices_dtype)
-        
-    
-    @parameterized.expand([
-        ("float16", torch.float16),
-        ("float32", torch.float32),
-        ("float64", torch.float64),
-    ])
+
+    @parameterized.expand(
+        [
+            ("float16", torch.float16),
+            ("float32", torch.float32),
+            ("float64", torch.float64),
+        ]
+    )
     def test_values_dtype(self, _, values_dtype):
-        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device)
+        A = generate_random_sparse_strictly_triangular_csr_matrix(
+            torch.Size([4, 4]), 5, values_dtype=values_dtype, device=self.device
+        )
         self.assertEqual(A.values().dtype, values_dtype)
-    
+
     # specific properties:
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 4),
-        ("2x4x4", torch.Size([2, 4, 4]), 4),
-        ("8x8", torch.Size([8, 8]), 28),
-        ("4x8x8", torch.Size([4, 8, 8]), 28),
-    ])
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 4),
+            ("2x4x4", torch.Size([2, 4, 4]), 4),
+            ("8x8", torch.Size([8, 8]), 28),
+            ("4x8x8", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_size_upper(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=True, device=self.device)
         self.assertEqual(A.size(), size)
-        
-    @parameterized.expand([
-        ("4x4", torch.Size([4, 4]), 4),
-        ("2x4x4", torch.Size([2, 4, 4]), 4),
-        ("8x8", torch.Size([8, 8]), 28),
-        ("4x8x8", torch.Size([4, 8, 8]), 28),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4", torch.Size([4, 4]), 4),
+            ("2x4x4", torch.Size([2, 4, 4]), 4),
+            ("8x8", torch.Size([8, 8]), 28),
+            ("4x8x8", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_size_lower(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=False, device=self.device)
         self.assertEqual(A.size(), size)
-    
-    
-    @parameterized.expand([
-        ("4x4_12nnz", torch.Size([4, 4]), 5),
-        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
-        ("8x8_22nnz", torch.Size([8, 8]), 22),
-        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4_12nnz", torch.Size([4, 4]), 5),
+            ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+            ("8x8_22nnz", torch.Size([8, 8]), 22),
+            ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_nnz_upper(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=True, device=self.device)
         # NOTE: CSR tensors return ._nnz() per batch element
         self.assertEqual(A._nnz(), nnz)
-        
-        
-    @parameterized.expand([
-        ("4x4_12nnz", torch.Size([4, 4]), 5),
-        ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
-        ("8x8_22nnz", torch.Size([8, 8]), 22),
-        ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
-    ])
+
+    @parameterized.expand(
+        [
+            ("4x4_12nnz", torch.Size([4, 4]), 5),
+            ("2x4x4_12nnz", torch.Size([2, 4, 4]), 4),
+            ("8x8_22nnz", torch.Size([8, 8]), 22),
+            ("4x8x8_28nnz", torch.Size([4, 8, 8]), 28),
+        ]
+    )
     def test_nnz_lower(self, _, size, nnz):
         A = generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=False, device=self.device)
         # NOTE: CSR tensors return ._nnz() per batch element
         self.assertEqual(A._nnz(), nnz)
-    
-        
+
     def test_is_strictly_upper(self):
         A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, upper=True, device=self.device)
         Ad = A.to_dense()
         self.assertTrue(torch.equal(Ad, Ad.triu(1)))
-        
+
     def test_is_strictly_lower(self):
-        A = generate_random_sparse_strictly_triangular_csr_matrix(torch.Size([4, 4]), 5, upper=False, device=self.device)
+        A = generate_random_sparse_strictly_triangular_csr_matrix(
+            torch.Size([4, 4]), 5, upper=False, device=self.device
+        )
         Ad = A.to_dense()
         print(Ad)
         self.assertTrue(torch.equal(Ad, Ad.tril(-1)))

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,6 +1,6 @@
 import unittest
 import torch
-from torchsparsegradutils.utils.random_sparse import _gencoordinates_2d, gencoordinates
+from torchsparsegradutils.utils.random_sparse import gencoordinates, gencoordinates_square_strictly_tri
 
 class TestGenCoordinates(unittest.TestCase):
     def setUp(self) -> None:
@@ -9,35 +9,152 @@ class TestGenCoordinates(unittest.TestCase):
             self.device = torch.device("cpu")
             
         self.size = torch.Size([4, 8, 16])
-        self.nnz = 32
+        self.nnz = 32  # nnz per batch element
         self.dtype = torch.int64
         
-        self.coo_coords_unbatched = _gencoordinates_2d(self.size[-2], self.size[-1], 
-                                                self.nnz, dtype=self.dtype, device=self.device)
+        self.coo_coords_unbatched = gencoordinates(self.size[-2:], self.nnz, layout=torch.sparse_coo,
+                                                   dtype=self.dtype, device=self.device)
         
         self.coo_coords_batched = gencoordinates(self.size, self.nnz, layout=torch.sparse_coo, 
                                                  dtype=self.dtype, device=self.device)
         
-    def test_gen_2d_shape(self):
+        self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates(self.size[-2:], self.nnz, layout=torch.sparse_csr,
+                                                    dtype=self.dtype, device=self.device)
+        
+        
+        self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates(self.size, self.nnz, layout=torch.sparse_csr,
+                                                    dtype=self.dtype, device=self.device)
+    
+    # error handling:    
+    def test_incorrect_shape(self):
+        with self.assertRaises(ValueError):
+            gencoordinates((1,) + self.size, self.nnz, layout=torch.sparse_coo, dtype=self.dtype, device=self.device)
+            
+    def test_incorrect_layout(self):
+        with self.assertRaises(ValueError):
+            gencoordinates(self.size, self.nnz, layout=torch.sparse_bsr, dtype=self.dtype, device=self.device)
+            
+    def test_too_many_nnz(self):
+        nnz = self.size[-2:].numel() + 1
+        with self.assertRaises(ValueError):
+            gencoordinates(self.size, nnz + 1, layout=torch.sparse_coo, dtype=self.dtype, device=self.device)
+    
+    # unmbacthed COO:    
+    def test_gencoords_coo_unbatched_shape(self):
         self.assertEqual(self.coo_coords_unbatched.shape, torch.Size([2, self.nnz]))
         
-    def test_gen_2d_unique(self):
+    def test_gencoords_coo_unbatched_unique(self):
         self.assertEqual(len(set([self.coo_coords_unbatched[:, i] for i in range(self.coo_coords_unbatched.shape[-1])])), self.nnz)
         
-    def test_gen_2d_range(self):
+    def test_gencoords_coo_unbatched_range(self):
+        print(self.coo_coords_unbatched)
         self.assertTrue((self.coo_coords_unbatched.t() < torch.tensor([self.size[-2], self.size[-1]])).all())
         
-    def test_gen_2d_device(self):
+    def test_gencoords_coo_unbatched_device(self):
         self.assertEqual(self.coo_coords_unbatched.device, self.device)
         
-    def test_gen_2d_dtype(self):
+    def test_gencoords_coo_unbatched_dtype(self):
         self.assertEqual(self.coo_coords_unbatched.dtype, self.dtype)
         
-    def test_gencoordinates_coo_batched_shape(self):
+    def test_gencoords_coo_unbatched_coords(self):
+        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        try:  
+            torch._validate_sparse_coo_tensor_args(self.coo_coords_unbatched, dummy_values, self.size[-2:])
+        except RuntimeError as e:
+            self.fail(f"Error: {e}")
+            
+    def test_gencoords_coo_unbatched_coords_int32_dtype(self):
+        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.coo_coords_unbatched.to(torch.int32), dummy_values, self.size[-2:])
+
+    # batched COO:    
+    def test_gencoords_coo_batched_shape(self):
         self.assertEqual(self.coo_coords_batched.shape, torch.Size([3, self.nnz*self.size[0]]))
         
-    def test_gencoordinate_coo_batched_device(self):
+    def test_gencoords_coo_batched_device(self):
         self.assertEqual(self.coo_coords_batched.device, self.device)
         
-    def test_gencoordinate_coo_batched_dtype(self):
+    def test_gencoords_coo_batched_dtype(self):
         self.assertEqual(self.coo_coords_batched.dtype, self.dtype)
+        
+    def test_gencoords_coo_batched_coords(self):
+        dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
+        try:  
+            torch._validate_sparse_coo_tensor_args(self.coo_coords_batched, dummy_values, self.size)
+        except RuntimeError as e:
+            self.fail(f"Error: {e}")
+             
+    def test_gencoords_coo_batched_coords_int32_dtype(self):
+        dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
+        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.coo_coords_batched.to(torch.int32), dummy_values, self.size)
+            
+    # unbatched CSR:
+    def test_gencoords_csr_unbatched_shape(self):
+        self.assertEqual(self.csr_crow_indices_unbatched.shape, torch.Size([self.size[-2] + 1]))
+        self.assertEqual(self.csr_col_indices_unbatched.shape, torch.Size([self.nnz]))
+        
+    def test_gencoords_csr_unbatched_device(self):
+        self.assertEqual(self.csr_crow_indices_unbatched.device, self.device)
+        self.assertEqual(self.csr_col_indices_unbatched.device, self.device)
+        
+    def test_gencoords_csr_unbatched_dtype(self):
+        self.assertEqual(self.csr_crow_indices_unbatched.dtype, self.dtype)
+        self.assertEqual(self.csr_col_indices_unbatched.dtype, self.dtype)
+        
+    def test_gencoords_csr_unbatched_coords(self):
+        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        try:  
+            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched, dummy_values, self.size[-2:])
+        except RuntimeError as e:
+            self.fail(f"Error: {e}")
+            
+    def test_gencoords_csr_unbatched_coords(self):
+        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
+        try:  
+            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched, dummy_values, self.size[-2:])
+        except RuntimeError as e:
+            self.fail(f"Error: {e}")
+    
+    # batched CSR:
+    def test_gencoords_csr_batched_shape(self):
+        self.assertEqual(self.csr_crow_indices_batched.shape, torch.Size([self.size[0], self.size[-2] + 1]))
+        self.assertEqual(self.csr_col_indices_batched.shape, torch.Size([self.size[0], self.nnz]))
+        
+    def test_gencoords_csr_batched_device(self):
+        self.assertEqual(self.csr_crow_indices_batched.device, self.device)
+        self.assertEqual(self.csr_col_indices_batched.device, self.device)
+        
+    def test_gencoords_csr_batched_dtype(self):
+        self.assertEqual(self.csr_crow_indices_batched.dtype, self.dtype)
+        self.assertEqual(self.csr_col_indices_batched.dtype, self.dtype)
+        
+    def test_gencoords_csr_batched_coords(self):
+        dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device).repeat(self.size[0], 1)
+        try:  
+            torch._validate_sparse_csr_tensor_args(self.csr_crow_indices_batched, self.csr_col_indices_batched, dummy_values, self.size)
+        except RuntimeError as e:
+            self.fail(f"Error: {e}")
+    
+
+class TestGenCoordinatesTril(TestGenCoordinates):
+    def setUp(self) -> None:
+        # The device can be specialised by a daughter class
+        if not hasattr(self, "device"):
+            self.device = torch.device("cpu")
+            
+        self.size = torch.Size([4, 12, 12])
+        self.nnz = 32  # nnz per batch element
+        self.dtype = torch.int64
+        
+        self.coo_coords_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_coo,
+                                                   dtype=self.dtype, device=self.device)
+        
+        self.coo_coords_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_coo, 
+                                                 dtype=self.dtype, device=self.device)
+        
+        self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_csr,
+                                                    dtype=self.dtype, device=self.device)
+        
+        
+        self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_csr,
+                                                    dtype=self.dtype, device=self.device)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -29,19 +29,32 @@ class TestGenRandomCOO(unittest.TestCase):
         with self.assertRaises(ValueError):
             generate_random_sparse_coo_matrix(torch.Size([4, 4]), 17)
     
+    
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+        ("int32", torch.int32),
+    ])
+    def test_incompatible_indices_dtype(self, _, indices_dtype):
+        with self.assertWarns(UserWarning):
+            generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
+    
     # basic properties:        
     def test_device(self):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, device=self.device)
         self.assertEqual(A.device.type, self.device.type)
     
+    
     @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
         ("int32", torch.int32),
         ("int64", torch.int64),
-    ])
+    ])  # NOTE: only torch.int64 is supported for COO indices, all other dtypes are casted to torch.int64
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
         self.assertEqual(A.indices().dtype, torch.int64)
-        # NOTE: int32 is not supported for COO indices, it will be converted to int64
+        
     
     @parameterized.expand([
         ("float16", torch.float16),
@@ -51,6 +64,7 @@ class TestGenRandomCOO(unittest.TestCase):
     def test_values_dtype(self, _, values_dtype):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
         self.assertEqual(A.values().dtype, values_dtype)
+    
         
     @parameterized.expand([
         ("4x4", torch.Size([4, 4]), 12),
@@ -61,6 +75,7 @@ class TestGenRandomCOO(unittest.TestCase):
     def test_size(self, _, size, nnz):
         A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
         self.assertEqual(A.size(), size)
+    
     
     @parameterized.expand([
         ("4x4", torch.Size([4, 4]), 12),
@@ -95,6 +110,14 @@ class TestGenRandomCSR(unittest.TestCase):
     def test_too_many_nnz(self):
         with self.assertRaises(ValueError):
             generate_random_sparse_csr_matrix(torch.Size([4, 4]), 17)
+            
+    @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
+    ])
+    def test_incompatible_indices_dtype(self, _, indices_dtype):
+        with self.assertWarns(UserWarning):
+            generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype)
     
     # basic properties:        
     def test_device(self):
@@ -103,9 +126,11 @@ class TestGenRandomCSR(unittest.TestCase):
     
     
     @parameterized.expand([
+        ("int08", torch.int8),
+        ("int16", torch.int16),
         ("int32", torch.int32),
         ("int64", torch.int64),
-    ])
+    ])  # NOTE: All integer dtypes are supported for CSR indices, although below int32 is not recommended
     def test_indices_dtype(self, _, indices_dtype):
         A = generate_random_sparse_csr_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
         self.assertEqual(A.crow_indices().dtype, indices_dtype)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,43 @@
+import unittest
+import torch
+from torchsparsegradutils.utils.random_sparse import _gencoordinates_2d, gencoordinates
+
+class TestGenCoordinates(unittest.TestCase):
+    def setUp(self) -> None:
+        # The device can be specialised by a daughter class
+        if not hasattr(self, "device"):
+            self.device = torch.device("cpu")
+            
+        self.size = torch.Size([4, 8, 16])
+        self.nnz = 32
+        self.dtype = torch.int64
+        
+        self.coo_coords_unbatched = _gencoordinates_2d(self.size[-2], self.size[-1], 
+                                                self.nnz, dtype=self.dtype, device=self.device)
+        
+        self.coo_coords_batched = gencoordinates(self.size, self.nnz, layout=torch.sparse_coo, 
+                                                 dtype=self.dtype, device=self.device)
+        
+    def test_gen_2d_shape(self):
+        self.assertEqual(self.coo_coords_unbatched.shape, torch.Size([2, self.nnz]))
+        
+    def test_gen_2d_unique(self):
+        self.assertEqual(len(set([self.coo_coords_unbatched[:, i] for i in range(self.coo_coords_unbatched.shape[-1])])), self.nnz)
+        
+    def test_gen_2d_range(self):
+        self.assertTrue((self.coo_coords_unbatched.t() < torch.tensor([self.size[-2], self.size[-1]])).all())
+        
+    def test_gen_2d_device(self):
+        self.assertEqual(self.coo_coords_unbatched.device, self.device)
+        
+    def test_gen_2d_dtype(self):
+        self.assertEqual(self.coo_coords_unbatched.dtype, self.dtype)
+        
+    def test_gencoordinates_coo_batched_shape(self):
+        self.assertEqual(self.coo_coords_batched.shape, torch.Size([3, self.nnz*self.size[0]]))
+        
+    def test_gencoordinate_coo_batched_device(self):
+        self.assertEqual(self.coo_coords_batched.device, self.device)
+        
+    def test_gencoordinate_coo_batched_dtype(self):
+        self.assertEqual(self.coo_coords_batched.dtype, self.dtype)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,193 +1,79 @@
 import unittest
-from parameterized import parameterized_class
+from parameterized import parameterized, parameterized_class
 import torch
 from torchsparsegradutils.utils.random_sparse import (
-    generate_sparse_coo_matrix_indices, 
-    generate_sparse_csr_matrix_indices,
-    generate_sparse_coo_matrix_indices_strictly_triangular,
-    generate_sparse_csr_matrix_indices_strictly_triangular,
+    generate_random_sparse_coo_matrix, 
+    generate_random_sparse_csr_matrix,
     )
 
 
-@parameterized_class(('size', 'nnz', 'dtype'), [
-    (torch.Size([   4,  4]), 12, torch.int64),
-    (torch.Size([2, 4,  4]), 12, torch.int64),
-    (torch.Size([   8, 16]), 32, torch.int64),
-    (torch.Size([4, 8, 16]), 32, torch.int64),
-    (torch.Size([4, 8, 16]),  2, torch.int64),
-    # NOTE: int32 is not supported for COO indices
+@parameterized_class(('name', 'device',), [
+    ("CPU", torch.device("cpu")),
+    ("CUDA", torch.device("cuda"),),
 ])
-class TestGenIndicesCOO(unittest.TestCase):
+class TestGenRandomCOO(unittest.TestCase):
     def setUp(self) -> None:
-        # The device can be specialised by a daughter class
-        if not hasattr(self, "device"):
-            self.device = torch.device("cpu")
-        
-        self.indices = generate_sparse_coo_matrix_indices(self.size, self.nnz, dtype=self.dtype, device=self.device)
+        if not torch.cuda.is_available() and self.device == torch.device("cuda"):
+            self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
         
     # error handling:
     def test_too_few_dims(self):
         with self.assertRaises(ValueError):
-            generate_sparse_coo_matrix_indices(torch.Size([1]), self.nnz, dtype=self.dtype, device=self.device)
+            generate_random_sparse_coo_matrix(torch.Size([16]), 6)
                 
     def test_too_many_dims(self):
         with self.assertRaises(ValueError):
-            if len(self.size) == 2:
-                generate_sparse_coo_matrix_indices((1, 1) + self.size, self.nnz, dtype=self.dtype, device=self.device)
-            elif len(self.size) == 3:
-                generate_sparse_coo_matrix_indices((1,) + self.size, self.nnz, dtype=self.dtype, device=self.device)
-            
-    def test_too_many_nnz(self):
-        nnz = self.size[-2:].numel() + 1
-        with self.assertRaises(ValueError):
-            generate_sparse_coo_matrix_indices(self.size, nnz, dtype=self.dtype, device=self.device)
-    
-    # basic properties:        
-    def test_gencoords_device(self):
-        self.assertEqual(self.indices.device, self.device)
-        
-    def test_gencoords_dtype(self):
-        self.assertEqual(self.indices.dtype, self.dtype)
-        
-    # specific properties:
-    def test_shape(self):
-        if len(self.size) == 2:
-            self.assertEqual(self.indices.shape, torch.Size([2, self.nnz]))
-        elif len(self.size) == 3:
-            self.assertEqual(self.indices.shape, torch.Size([3, self.nnz*self.size[0]]))
-        
-    def test_unique(self):
-        if len(self.size) == 2:
-            self.assertEqual(len(set([self.indices[:, i] for i in range(self.indices.shape[-1])])), self.nnz)
-        elif len(self.size) == 3:
-            self.assertEqual(len(set([self.indices[1:, :] for i in range(self.indices.shape[-1]//self.size[0])])), self.nnz)
-            
-    def test_range(self):
-        if len(self.size) == 2:
-            self.assertTrue((self.indices.t() < torch.tensor([self.size[-2], self.size[-1]])).all())
-        elif len(self.size) == 3:
-            self.assertTrue((self.indices[1:, :].t() < torch.tensor([self.size[-2], self.size[-1]])).all())
-            
-    def test_indices(self):
-        if len(self.size) == 2:
-            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        elif len(self.size) == 3:
-            dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
-            
-        try:  
-            torch._validate_sparse_coo_tensor_args(self.indices, dummy_values, self.size)
-        except RuntimeError as e:
-                self.fail(f"Error: {e}")
-            
-    def test_indices_int32(self):
-        if len(self.size) == 2:
-            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        elif len(self.size) == 3:
-            dummy_values = torch.ones(self.nnz*self.size[0], dtype=torch.float32, device=self.device)
-        self.assertRaises(RuntimeError, torch._validate_sparse_coo_tensor_args, self.indices.to(torch.int32), dummy_values, self.size)
-        
-        
-@parameterized_class(('size', 'nnz', 'dtype'), [
-    (torch.Size([   4,  4]), 12, torch.int64),
-    (torch.Size([2, 4,  4]), 12, torch.int64),
-    (torch.Size([   8, 16]), 32, torch.int64),
-    (torch.Size([4, 8, 16]), 32, torch.int64),
-    (torch.Size([4, 8, 16]), 32, torch.int32),  # int32 works with CSR
-    (torch.Size([4, 8, 16]),  2, torch.int64),
-])        
-class TestGenIndicesCSR(unittest.TestCase):
-    def setUp(self) -> None:
-        # The device can be specialised by a daughter class
-        if not hasattr(self, "device"):
-            self.device = torch.device("cpu")
-        
-        self.crow_indices, self.col_indices = generate_sparse_csr_matrix_indices(self.size, self.nnz, dtype=self.dtype, device=self.device)
-        
-    # error handling:
-    def test_too_few_dims(self):
-        with self.assertRaises(ValueError):
-            generate_sparse_csr_matrix_indices(torch.Size([1]), self.nnz, dtype=self.dtype, device=self.device)
-                
-    def test_too_many_dims(self):
-        with self.assertRaises(ValueError):
-            if len(self.size) == 2:
-                generate_sparse_csr_matrix_indices((1, 1) + self.size, self.nnz, dtype=self.dtype, device=self.device)
-            elif len(self.size) == 3:
-                generate_sparse_csr_matrix_indices((1,) + self.size, self.nnz, dtype=self.dtype, device=self.device)
-            
-    def test_too_many_nnz(self):
-        nnz = self.size[-2:].numel() + 1
-        with self.assertRaises(ValueError):
-            generate_sparse_csr_matrix_indices(self.size, nnz, dtype=self.dtype, device=self.device)
-    
-    # basic properties:        
-    def test_gencoords_device(self):
-        self.assertEqual(self.crow_indices.device, self.device)
-        self.assertEqual(self.col_indices.device, self.device)
-        
-    def test_gencoords_dtype(self):
-        self.assertEqual(self.crow_indices.dtype, self.dtype)
-        self.assertEqual(self.col_indices.device, self.device)
-        
-    # specific properties:
-    def test_shape(self):
-       if len(self.size) == 2:
-            self.assertEqual(self.crow_indices.shape, torch.Size([self.size[-2] + 1]))
-            self.assertEqual(self.col_indices.shape, torch.Size([self.nnz]))
-       elif len(self.size) == 3:
-            self.assertEqual(self.crow_indices.shape, torch.Size([self.size[0], self.size[-2] + 1]))
-            self.assertEqual(self.col_indices.shape, torch.Size([self.size[0], self.nnz]))
-            
-    def test_unique(self):
-        self.skipTest("Cannot test CSR matrices for uniqueness. In other words they cannot be coalesced.")
-        
-    def test_range(self):
-        if len(self.size) == 2:
-            self.assertEqual(self.crow_indices[0], 0)
-            self.assertEqual(self.crow_indices[-1], self.nnz)
-            self.assertTrue((self.col_indices < torch.tensor([self.size[-1]])).all())
-        elif len(self.size) == 3:
-            self.assertEqual(self.crow_indices[0, 0], 0)
-            self.assertEqual(self.crow_indices[0, -1], self.nnz)
-            self.assertTrue((self.col_indices[0] < torch.tensor([self.size[-1]])).all())
-            
-    def test_indices(self):
-        if len(self.size) == 2:
-            dummy_values = torch.ones(self.nnz, dtype=torch.float32, device=self.device)
-        elif len(self.size) == 3:
-            dummy_values = torch.ones(self.size[0], self.nnz, dtype=torch.float32, device=self.device)
-            
-        try:  
-            torch._validate_sparse_csr_tensor_args(self.crow_indices, self.col_indices, dummy_values, self.size)
-        except RuntimeError as e:
-                self.fail(f"Error: {e}")
+            generate_random_sparse_coo_matrix(torch.Size([4, 4, 8, 8]), 32)
 
+    def test_too_many_nnz(self):
+        with self.assertRaises(ValueError):
+            generate_random_sparse_coo_matrix(torch.Size([4, 4]), 17)
     
-# @parameterized_class(('size', 'nnz', 'layout', 'dtype'), [
-#     (torch.Size([   12, 12]), 32, torch.sparse_coo, torch.int64),
-#     (torch.Size([4, 12, 12]), 32, torch.sparse_coo, torch.int64),
-#     # NOTE: int32 is not supported for COO indices
+    # basic properties:        
+    def test_device(self):
+        A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, device=self.device)
+        self.assertEqual(A.device.type, self.device.type)
     
-#     (torch.Size([   12, 12]), 32, torch.sparse_csr, torch.int64),
-#     (torch.Size([4, 12, 12]), 32, torch.sparse_csr, torch.int64),
-#     (torch.Size([4, 12, 12]), 32, torch.sparse_csr, torch.int32),
-# ])
-# class TestGenCoordinatesTril(TestGenCoordinates):
-#     def setUp(self) -> None:
-#         super().setUp()    
-#         # self.size = torch.Size([4, 12, 12])
-#         # self.nnz = 32  # nnz per batch element
-#         self.dtype = torch.int64
+    @parameterized.expand([
+        ("int32", torch.int32),
+        ("int64", torch.int64),
+    ])
+    def test_indices_dtype(self, _, indices_dtype):
+        A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, indices_dtype=indices_dtype, device=self.device)
+        A = A.coalesce()
+        self.assertEqual(A.indices().dtype, torch.int64)
+        # NOTE: int32 is not supported for COO indices, it will be converted to int64
+    
+    @parameterized.expand([
+        ("float16", torch.float16),
+        ("float32", torch.float32),
+        ("float64", torch.float64),
+    ])
+    def test_values_dtype(self, _, values_dtype):
+        A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
+        A = A.coalesce()
+        self.assertEqual(A.values().dtype, values_dtype)
         
-#         self.coo_coords_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_coo,
-#                                                    dtype=self.dtype, device=self.device)
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 12),
+        ("2x4x4", torch.Size([2, 4, 4]), 12),
+        ("8x16", torch.Size([8, 16]), 32),
+        ("4x8x16", torch.Size([4, 8, 16]), 32),
+    ])
+    def test_size(self, _, size, nnz):
+        A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
+        A = A.coalesce()
+        self.assertEqual(A.size(), size)
+    
+    @parameterized.expand([
+        ("4x4", torch.Size([4, 4]), 12),
+        ("2x4x4", torch.Size([2, 4, 4]), 12),
+        ("8x16", torch.Size([8, 16]), 32),
+        ("4x8x16", torch.Size([4, 8, 16]), 32),
+    ])
+    def test_nnz(self, _, size, nnz):
+        A = generate_random_sparse_coo_matrix(size, nnz, device=self.device)
+        A = A.coalesce()
+        self.assertEqual(A._nnz(), nnz*((1,)+size)[-3])
+            
         
-#         self.coo_coords_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_coo, 
-#                                                  dtype=self.dtype, device=self.device)
-        
-#         self.csr_crow_indices_unbatched, self.csr_col_indices_unbatched = gencoordinates_square_strictly_tri(self.size[-2:], self.nnz, layout=torch.sparse_csr,
-#                                                     dtype=self.dtype, device=self.device)
-        
-        
-#         self.csr_crow_indices_batched, self.csr_col_indices_batched = gencoordinates_square_strictly_tri(self.size, self.nnz, layout=torch.sparse_csr,
-#                                                     dtype=self.dtype, device=self.device)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -11,6 +11,7 @@ from torchsparsegradutils.utils.random_sparse import (
 # https://pytorch.org/docs/stable/generated/torch.sparse.check_sparse_tensor_invariants.html#torch.sparse.check_sparse_tensor_invariants
 torch.sparse.check_sparse_tensor_invariants.enable()
 
+
 @parameterized_class(
     (
         "name",
@@ -78,7 +79,6 @@ class TestGenRandomCOO(unittest.TestCase):
         A = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, values_dtype=values_dtype, device=self.device)
         self.assertEqual(A.values().dtype, values_dtype)
 
-    
     @parameterized.expand(
         [
             ("4x4", torch.Size([4, 4]), 12),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,7 +1,7 @@
 import torch
 import unittest
 from parameterized import parameterized_class, parameterized
-from torchsparsegradutils.utils.random_sparse import generate_random_sparse_coo_matrix
+from torchsparsegradutils.utils.random_sparse import generate_random_sparse_coo_matrix, generate_random_sparse_strictly_triangular_coo_matrix
 from torchsparsegradutils.utils.utils import compress_row_indices, demcompress_crow_indices
 
 from torchsparsegradutils.utils.utils import (
@@ -14,9 +14,22 @@ from torchsparsegradutils.utils.utils import (
 ])
 class TestRowIndicesCompressionDecompression(unittest.TestCase):
     def setUp(self) -> None:
-        self.A_coo = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, device=self.device)
+        self.A_coo = generate_random_sparse_coo_matrix(torch.Size([8, 8]), 12, device=self.device)
+        self.A_coo_tril = generate_random_sparse_strictly_triangular_coo_matrix(torch.Size([8, 8]), 12, device=self.device)
         self.A_csr = self.A_coo.to_sparse_csr()
+        self.A_csr_tril = self.A_coo_tril.to_sparse_csr()
         
+    # row compression cannot be done without sorting the col indices and applying the same sort change to the values
+    
+    # TODO: these unit tests need to build a CSR from the compressed and then convert back
+    # as they do not check either the values or the column indices
+    
+    # TODO: let's also check the other way around, i.e. CSR to COO
+    # I could just use to .to_sparse_coo() and .to_sparse_csr() methods
+    # however, that would force conversion to int64, which won't be ideal for my use case
+    # Having a way to convert COO - CSR indices, strictly in int32 is useful and will prevent the memory errors I have been having
+    # Would also be nice to be able to do this batched.
+    
     def test_compress_row_indices(self):
         row_idx, col_idx = self.A_coo.indices()
         crow_idx = compress_row_indices(row_idx, self.A_coo.shape[0])
@@ -26,6 +39,16 @@ class TestRowIndicesCompressionDecompression(unittest.TestCase):
         crow_idx = self.A_csr.crow_indices()
         row_idx = demcompress_crow_indices(crow_idx, self.A_coo.shape[0])
         self.assertTrue(torch.allclose(row_idx, self.A_coo.indices()[0]))
+        
+    def test_compress_row_indices_tril(self):
+        row_idx, col_idx = self.A_coo_tril.indices()
+        crow_idx = compress_row_indices(row_idx, self.A_coo_tril.shape[0])
+        self.assertTrue(torch.allclose(crow_idx, self.A_csr_tril.crow_indices()))
+        
+    def test_demcompress_crow_indices_tril(self):
+        crow_idx = self.A_csr_tril.crow_indices()
+        row_idx = demcompress_crow_indices(crow_idx, self.A_coo_tril.shape[0])
+        self.assertTrue(torch.allclose(row_idx, self.A_coo_tril.indices()[0]))
         
     @parameterized.expand([
         ("int32", torch.int32),

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,8 @@ from torchsparsegradutils.utils.utils import (
     convert_coo_to_csr,
 )
 
+# https://pytorch.org/docs/stable/generated/torch.sparse.check_sparse_tensor_invariants.html#torch.sparse.check_sparse_tensor_invariants
+torch.sparse.check_sparse_tensor_invariants.enable()
 
 @parameterized_class(
     (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,13 +1,44 @@
 import torch
 import unittest
-from parameterized import parameterized_class
+from parameterized import parameterized_class, parameterized
+from torchsparsegradutils.utils.random_sparse import generate_random_sparse_coo_matrix
+from torchsparsegradutils.utils.utils import compress_row_indices, demcompress_crow_indices
 
 from torchsparsegradutils.utils.utils import (
     compress_row_indices,
     demcompress_crow_indices,
 )
-
+@parameterized_class(('name', 'device',), [
+    ("CPU", torch.device("cpu")),
+    ("CUDA", torch.device("cuda"),),
+])
 class TestRowIndicesCompressionDecompression(unittest.TestCase):
     def setUp(self) -> None:
-        pass
-
+        self.A_coo = generate_random_sparse_coo_matrix(torch.Size([4, 4]), 12, device=self.device)
+        self.A_csr = self.A_coo.to_sparse_csr()
+        
+    def test_compress_row_indices(self):
+        row_idx, col_idx = self.A_coo.indices()
+        crow_idx = compress_row_indices(row_idx, self.A_coo.shape[0])
+        self.assertTrue(torch.allclose(crow_idx, self.A_csr.crow_indices()))
+        
+    def test_demcompress_crow_indices(self):
+        crow_idx = self.A_csr.crow_indices()
+        row_idx = demcompress_crow_indices(crow_idx, self.A_coo.shape[0])
+        self.assertTrue(torch.allclose(row_idx, self.A_coo.indices()[0]))
+        
+    @parameterized.expand([
+        ("int32", torch.int32),
+        ("int64", torch.int64),
+    ])
+    def test_indices_dtype(self, _, indices_dtype):
+        num_rows = 4
+        row_idx  = torch.tensor([0, 0, 0, 1, 2, 2, 2, 2, 3, 3, 3, 3], dtype=indices_dtype, device=self.device)
+        crow_idx = compress_row_indices(row_idx, num_rows)
+        self.assertEqual(crow_idx.dtype, indices_dtype)
+        
+    def test_device(self):
+        num_rows = 4
+        row_idx  = torch.tensor([0, 0, 0, 1, 2, 2, 2, 2, 3, 3, 3, 3], dtype=torch.int32, device=self.device)
+        crow_idx = compress_row_indices(row_idx, num_rows)
+        self.assertEqual(crow_idx.device.type, self.device.type)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,13 @@
+import torch
+import unittest
+from parameterized import parameterized_class
+
+from torchsparsegradutils.utils.utils import (
+    compress_row_indices,
+    demcompress_crow_indices,
+)
+
+class TestRowIndicesCompressionDecompression(unittest.TestCase):
+    def setUp(self) -> None:
+        pass
+

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -16,6 +16,7 @@ from torchsparsegradutils.utils.utils import (
 # https://pytorch.org/docs/stable/generated/torch.sparse.check_sparse_tensor_invariants.html#torch.sparse.check_sparse_tensor_invariants
 torch.sparse.check_sparse_tensor_invariants.enable()
 
+
 @parameterized_class(
     (
         "name",

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -2,16 +2,15 @@
 utility functions for generating random sparse matrices
 
 NOTE: sparse COO tensors have indices tensor of size (ndim, nse) and with element type torch.int64
-
 NOTE: Sparse CSR The index tensors crow_indices and col_indices should have element type either torch.int64 (default) or torch.int32. 
-If you want to use MKL-enabled matrix operations, use torch.int32. 
-This is as a result of the default linking of pytorch being with MKL LP64, which uses 32 bit integer indexing
+      If you want to use MKL-enabled matrix operations, use torch.int32. 
+      This is as a result of the default linking of pytorch being with MKL LP64, which uses 32 bit integer indexing
 """
 
 import torch
-from random import randrange
+import random
 
-def _gencoordinates_2d(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
+def _gencoordinates_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Used to genererate nnz random unique coordinates
     
     Args:
@@ -23,35 +22,250 @@ def _gencoordinates_2d(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("c
     Returns:
         torch.tensor: tensor of shape [2, nnz] containing the generated coordinates
     """
+    assert nnz <= nr * nc, "Number of elements (nnz) must be less than or equal to the total number of elements (nr * nc)."
+    
     coordinates = set()
     while True:
-        r, c = randrange(nr), randrange(nc)
+        r, c = random.randrange(nr), random.randrange(nc)
         coordinates.add((r, c))
         if len(coordinates) == nnz:
             return torch.stack([torch.tensor(co, dtype=dtype) for co in coordinates], dim=-1).to(device)
 
 
-def gencoordinates(size, nnz, *, layout=torch.sparse_coo, dtype=torch.int64, device=torch.device("cpu")):
+def _gencoordinates_2d_csr(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to genererate nnz random unique csr coordinates
+    
+    Args:
+        nr (int): number of rows
+        nc (int): number of columns
+        nnz (int): number of elements the generated csr indices represent
+        device (torch.device, optional): device to generate coordinates on. Defaults to torch.device("cpu").
+
+    Returns:
+        crow_indices (torch.tensor): tensor of shape [nr+1] containing the generated crow_indices
+        col_indices (torch.tensor): tensor of shape [nnz] containing the generated col_indices
     """
-    Used to genererate nnz random unique COO or CSR coordinates for sparse matrix specified by size
+        
+    assert nnz <= nr * nc, "Number of elements (nnz) must be less than or equal to the total number of elements (nr * nc)."
+    
+    crow_indices = torch.zeros(nr+1, dtype=dtype, device=device)
+    col_indices = torch.zeros(nnz, dtype=dtype, device=device)
+    
+    for i in range(nr):
+        if i == nr - 1:
+            step = nnz - crow_indices[i]  # if we reach the last step, we set step size to ensure we reach nnz
+        else:
+            step = torch.randint(0, min(nc+1, nnz - crow_indices[i] - (nr - i)), (1,))
+        crow_indices[i+1] = crow_indices[i] + step
+        
+        col_indices[crow_indices[i]:crow_indices[i+1]] = torch.sort(torch.randperm(nc)[:step])[0]
+
+    return crow_indices, col_indices
+
+  
+def gencoordinates(size, nnz, *, layout=torch.sparse_coo, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to genererate nnz random unique COO or CSR coordinates for batched sparse matrix specified by size ((b), nr, nc).
     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
     Currently, for simplicity, this implementation uses the same indices for each batch element.
-    Therefore, the coordinates are unique for each bathc element, but not across batch elements.
+    Therefore, the coordinates are unique for each batch element, but not across batch elements.
+
+    Args:
+        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((nr, nc)) for a single batch or ((b), nr, nc) for a batched matrix, where (b) represents the number of batch elements.
+        nnz (int): Number of elements the generated COO or CSR indices represent. This must be less than or equal to the total number of elements in the matrix.
+        layout (torch.layout, optional): Layout of the sparse matrix, either torch.sparse_coo or torch.sparse_csr. Defaults to torch.sparse_coo.
+        dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
+        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
+
+
+    Raises:
+        ValueError: Raised if size has less than 2 dimensions.
+        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+        ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
+        ValueError: Raised if the layout is not torch.sparse_coo or torch.sparse_csr.
+
+    Returns:
+        torch.Tensor: returns a tensor of shape [ndim, nnz] for COO layout or [nr+1] and [nnz] for CSR layout
     """
     if len(size) < 2:
         raise ValueError("size must have at least 2 dimensions")
     elif len(size) > 3:
         raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
-            
-    coo_coordinates = _gencoordinates_2d(size[-2], size[-1], nnz, dtype=dtype, device=device)
+    
+    if nnz > size[-2] * size[-1]:
+        raise ValueError("nnz must be less than or equal to nr * nc")
     
     if layout == torch.sparse_coo:
+        unbatched_coo_coordinates = _gencoordinates_2d_coo(size[-2], size[-1], nnz, dtype=dtype, device=device)
         if len(size) == 2:
-            return coo_coordinates
+            return unbatched_coo_coordinates
         else:
-            sparse_dim_coordinates = torch.cat([coo_coordinates] * size[0], dim=-1)
+            sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
             batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
             return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
+        
+    elif layout == torch.sparse_csr:
+        crow_indices, col_indices = _gencoordinates_2d_csr(size[-2], size[-1], nnz, dtype=dtype, device=device)
+        if len(size) == 2:
+            return crow_indices, col_indices
+        else:
+            crow_indices = crow_indices.repeat(size[0], 1)
+            col_indices = col_indices.repeat(size[0], 1)
+            return crow_indices, col_indices
+    else:
+        raise ValueError(f"layout must be torch.sparse_coo or torch.sparse_csr, but got layout {layout}")
+
+
+# Square strictly Triangular:
+
+def _gencoordinates_2d_coo_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to generate nnz random unique COO coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
+
+    Args:
+        n (int): Size of the square matrix (number of rows and columns).
+        nnz (int): Number of elements the generated COO indices represent.
+        upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
+        dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
+        device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+
+    Returns:
+        indices (torch.Tensor): Tensor of shape [2, nnz] containing the generated COO indices.
+    """
+    assert nnz <= n * (n - 1) // 2, "Number of elements (nnz) must be less than or equal to the total number of elements (n * (n - 1) // 2)."
+
+    coordinates = set()
+    while True:
+            r, c = random.randrange(n), random.randrange(n)
+            if (r < c and upper) or (r > c and not upper):
+                coordinates.add((r, c))
+            if len(coordinates) == nnz:
+                return torch.stack([torch.tensor(co) for co in coordinates], dim=-1).to(device)
+
     
+def _gencoordinates_2d_csr_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to generate nnz random unique csr coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
     
+    Args:
+        n (int): Number of rows and columns (since it's a square matrix).
+        nnz (int): Number of elements the generated csr indices represent.
+        upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
+        dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
+        device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+
+    Returns:
+        crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the generated crow_indices.
+        col_indices (torch.Tensor): Tensor of shape [nnz] containing the generated col_indices.
+    """
+    assert nnz <= n * n, "Number of elements (nnz) must be less than or equal to the total number of elements (n * n)."
+    assert n == n, "Number of rows (nr) must be equal to the number of columns (nc) to create a square matrix."
     
+    crow_indices = torch.zeros(n+1, dtype=dtype, device=device)
+    col_indices = torch.zeros(nnz, dtype=dtype, device=device)
+    
+    for i in range(n):
+        if i == n - 1:
+            step = nnz - crow_indices[i]  # If we reach the last step, we set the step size to ensure we reach nnz.
+        else:
+            max_step = min(n-i, nnz - crow_indices[i] - (n - i))
+            step = random.randint(0, max_step+1) if upper else torch.randint(1, max_step+1)
+        crow_indices[i+1] = crow_indices[i] + step
+        
+        if upper:
+            col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(i+1, i+1+step, device=device)
+        else:
+            col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(0, step, device=device)
+
+    return crow_indices, col_indices
+        
+        
+def gencoordinates_square_strictly_tri(size, nnz, *, upper=True, layout=torch.sparse_coo, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to genererate nnz random unique COO or CSR coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
+    As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
+    Currently, for simplicity, this implementation uses the same indices for each batch element.
+    Therefore, the coordinates are unique for each batch element, but not across batch elements.
+
+    Args:
+        size (tuple): _description_
+        nnz (int): _description_
+        layout (torch.layout, optional): _description_. Defaults to torch.sparse_coo.
+        dtype (torch.dtype, optional): _description_. Defaults to torch.int64.
+        device (torch.device, optional): _description_. Defaults to torch.device("cpu").
+
+    Raises:
+        ValueError: Raised if size has less than 2 dimensions.
+        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+        ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
+        ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
+        ValueError: Raised if the layout is not torch.sparse_coo or torch.sparse_csr.
+
+    Returns:
+        torch.Tensor: returns a tensor of shape [ndim, nnz] for COO layout or [nr+1] and [nnz] for CSR layout
+    """
+    if len(size) < 2:
+        raise ValueError("size must have at least 2 dimensions")
+    elif len(size) > 3:
+        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+    
+    if size[-2] != size[-1]:
+        raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
+    
+    if nnz > size[-2] * size[-1]:
+        raise ValueError("nnz must be less than or equal to n * n")
+    
+    if layout == torch.sparse_coo:
+        unbatched_coo_coordinates = _gencoordinates_2d_coo_strictly_tri(size[-2], nnz, dtype=dtype, device=device)
+        if len(size) == 2:
+            return unbatched_coo_coordinates
+        else:
+            sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
+            batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
+            return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
+        
+    elif layout == torch.sparse_csr:
+        crow_indices, col_indices = _gencoordinates_2d_csr_strictly_tri(size[-2], nnz, dtype=dtype, device=device)
+        if len(size) == 2:
+            return crow_indices, col_indices
+        else:
+            crow_indices = crow_indices.repeat(size[0], 1)
+            col_indices = col_indices.repeat(size[0], 1)
+            return crow_indices, col_indices
+    else:
+        raise ValueError(f"layout must be torch.sparse_coo or torch.sparse_csr, but got layout {layout}")
+    
+
+
+
+
+
+
+
+
+
+
+
+
+# unit test and move to contraints
+def is_strictly_triangular(crow_indices, col_indices, upper=True):
+    """Check whether the given crow_indices and col_indices represent strictly upper triangular or strictly lower triangular indices.
+    
+    Args:
+        crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the crow_indices.
+        col_indices (torch.Tensor): Tensor of shape [nnz] containing the col_indices.
+        upper (bool, optional): Flag indicating whether to check for strictly upper triangular indices. Defaults to True.
+    
+    Returns:
+        bool: True if the indices are strictly upper triangular or strictly lower triangular, False otherwise.
+    """
+    assert crow_indices.dim() == 1 and col_indices.dim() == 1, "Input tensors must be 1-dimensional."
+    assert crow_indices.size(0) == crow_indices[-1], "crow_indices must represent a valid compressed sparse row structure."
+    assert col_indices.size(0) == crow_indices[-1], "col_indices must have the same length as crow_indices[-1]."
+    
+    if upper:
+        for i in range(crow_indices.size(0) - 1):
+            if (col_indices[crow_indices[i]:crow_indices[i+1]] <= i).any():
+                return False
+        return True
+    else:
+        for i in range(crow_indices.size(0) - 1):
+            if (col_indices[crow_indices[i]:crow_indices[i+1]] >= i+1).any():
+                return False
+        return True

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -10,23 +10,6 @@ NOTE: Sparse CSR The index tensors crow_indices and col_indices should have elem
 import torch
 import random
 
-# A better way of doing this is just to have two functions to generate the full matrices
-# And the coordinate function generators can be private methods
-# just use the coo indiex generator
-# write a function to compress rows
-# unit test with a simple .to_sparse_csr and use the random COO matrix generator
-# there are not many tests you need, as the construction of coo or csr will perform the _validate_sparse_coo_tensor_args type thing
-# just need to check:
-    # raises
-        # incorrect dims
-        # incorrect nnz
-    # devices
-    # types
-    # nnz
-    # shape
-
-# you have way too many checks and the whole thing is way bigger than it needs to be
-
 def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Used to genererate nnz random unique coordinates
     
@@ -46,51 +29,14 @@ def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("
         r, c = random.randrange(nr), random.randrange(nc)
         coordinates.add((r, c))
         if len(coordinates) == nnz:
-            return torch.stack([torch.tensor(co, dtype=dtype) for co in coordinates], dim=-1).to(device)
+            return torch.stack([torch.tensor(co, dtype=dtype, device=device) for co in coordinates], dim=-1)
     
     # Alternatively, could do:
     # indices = torch.randperm(nr * nc)[:nnz]
     # return torch.stack([indices // nc, indices % nc]).to(device)
-
-
-def generate_sparse_coo_matrix_indices(size, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to generate nnz random unique COO coordinates for a batched sparse matrix specified by size ((b), nr, nc).
-    As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-    Currently, for simplicity, this implementation uses the same indices for each batch element.
-    Therefore, the coordinates are unique for each batch element, but not across batch elements.
-
-    Args:
-        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((nr, nc)) for a single batch or ((b), nr, nc) for a batched matrix, where (b) represents the number of batch elements.
-        nnz (int): Number of elements the generated COO indices represent. This must be less than or equal to the total number of elements in the matrix.
-        dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
-        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
-
-    Raises:
-        ValueError: Raised if size has less than 2 dimensions.
-        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-        ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
-
-    Returns:
-        torch.Tensor: Returns a tensor of shape [ndim, nnz] containing the generated COO coordinates.
-    """
-    if len(size) < 2:
-        raise ValueError("size must have at least 2 dimensions")
-    elif len(size) > 3:
-        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
-
-    if nnz > size[-2] * size[-1]:
-        raise ValueError("nnz must be less than or equal to nr * nc")
-
-    unbatched_coo_coordinates = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=dtype, device=device)
-    if len(size) == 2:
-        return unbatched_coo_coordinates
-    else:
-        sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
-        batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
-        return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
     
     
-def generate_random_sparse_coo_matrix(size, nnz, *, dtype=torch.float32, device=torch.device("cpu")):
+def generate_random_sparse_coo_matrix(size, nnz, *, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
     """Used to generate a random sparse COO matrix.
     
     Args:
@@ -105,41 +51,33 @@ def generate_random_sparse_coo_matrix(size, nnz, *, dtype=torch.float32, device=
         ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
 
     Returns:
-        torch.Tensor: Returns a tensor of shape [ndim, nnz] containing the generated COO coordinates.
+        torch.Tensor: Returns a sparse COO tensor of shape size with nnz elements.
     """
-    indices = generate_sparse_coo_matrix_indices(size, nnz, dtype=dtype, device=device)
-    values = torch.rand(nnz, dtype=dtype, device=device)
-    return torch.sparse_coo_tensor(indices, values, size, device=device)
     
-    
-def _gen_indices_2d_csr(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to genererate nnz random unique csr coordinates
-    
-    Args:
-        nr (int): number of rows
-        nc (int): number of columns
-        nnz (int): number of elements the generated csr indices represent
-        device (torch.device, optional): device to generate coordinates on. Defaults to torch.device("cpu").
+    if len(size) < 2:
+        raise ValueError("size must have at least 2 dimensions")
+    elif len(size) > 3:
+        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
 
-    Returns:
-        crow_indices (torch.tensor): tensor of shape [nr+1] containing the generated crow_indices
-        col_indices (torch.tensor): tensor of shape [nnz] containing the generated col_indices
-    """
-        
-    assert nnz <= nr * nc, "Number of elements (nnz) must be less than or equal to the total number of elements (nr * nc)."
+    if nnz > size[-2] * size[-1]:
+        raise ValueError("nnz must be less than or equal to nr * nc")
     
-    indices = torch.randperm(nr * nc)[:nnz]  # this method may not be efficient for large matrices
-    matrix = torch.zeros(nr, nc)
-    matrix.view(-1)[indices] = 1
-    matrix = matrix.to_sparse_csr()
-    return matrix.crow_indices().to(dtype).to(device), matrix.col_indices().to(dtype).to(device)
+    if len(size) == 2:
+        coo_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
+        values = torch.rand(nnz, dtype=values_dtype, device=device)
+    else:
+        sparse_dim_indices = torch.cat([_gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device) for _ in range(size[0])], dim=-1)
+        # batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
+        batch_dim_indices = batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat_interleave(nnz).unsqueeze(0)
+        coo_indices = torch.cat([batch_dim_indices, sparse_dim_indices])
+        values = torch.rand(nnz*size[0], dtype=values_dtype, device=device)        
+
+    return torch.sparse_coo_tensor(coo_indices, values, size, device=device)
 
 
-def generate_sparse_csr_matrix_indices(size, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
+def generate_random_sparse_csr_matrix(size, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Used to generate nnz random unique CSR coordinates for a batched sparse matrix specified by size ((b), nr, nc).
     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-    Currently, for simplicity, this implementation uses the same indices for each batch element.
-    Therefore, the coordinates are unique for each batch element, but not across batch elements.
 
     Args:
         size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((nr, nc)) for a single batch or ((b), nr, nc) for a batched matrix, where (b) represents the number of batch elements.
@@ -163,7 +101,7 @@ def generate_sparse_csr_matrix_indices(size, nnz, *, dtype=torch.int64, device=t
     if nnz > size[-2] * size[-1]:
         raise ValueError("nnz must be less than or equal to nr * nc")
 
-    crow_indices, col_indices = _gen_indices_2d_csr(size[-2], size[-1], nnz, dtype=dtype, device=device)
+    row_idx, col_idx = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
     if len(size) == 2:
         return crow_indices, col_indices
     else:
@@ -172,150 +110,150 @@ def generate_sparse_csr_matrix_indices(size, nnz, *, dtype=torch.int64, device=t
         return crow_indices, col_indices
 
 
-# Square strictly Triangular:
+# # Square strictly Triangular:
 
-def _gen_indices_2d_coo_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to generate nnz random unique COO coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
+# def _gen_indices_2d_coo_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
+#     """Used to generate nnz random unique COO coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
 
-    Args:
-        n (int): Size of the square matrix (number of rows and columns).
-        nnz (int): Number of elements the generated COO indices represent.
-        upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
-        dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
-        device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+#     Args:
+#         n (int): Size of the square matrix (number of rows and columns).
+#         nnz (int): Number of elements the generated COO indices represent.
+#         upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
+#         dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
+#         device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
 
-    Returns:
-        indices (torch.Tensor): Tensor of shape [2, nnz] containing the generated COO indices.
-    """
-    assert nnz <= n * (n - 1) // 2, "Number of elements (nnz) must be less than or equal to the total number of elements (n * (n - 1) // 2)."
+#     Returns:
+#         indices (torch.Tensor): Tensor of shape [2, nnz] containing the generated COO indices.
+#     """
+#     assert nnz <= n * (n - 1) // 2, "Number of elements (nnz) must be less than or equal to the total number of elements (n * (n - 1) // 2)."
 
-    coordinates = set()
-    while True:
-            r, c = random.randrange(n), random.randrange(n)
-            if (r < c and upper) or (r > c and not upper):
-                coordinates.add((r, c))
-            if len(coordinates) == nnz:
-                return torch.stack([torch.tensor(co) for co in coordinates], dim=-1).to(device)
+#     coordinates = set()
+#     while True:
+#             r, c = random.randrange(n), random.randrange(n)
+#             if (r < c and upper) or (r > c and not upper):
+#                 coordinates.add((r, c))
+#             if len(coordinates) == nnz:
+#                 return torch.stack([torch.tensor(co) for co in coordinates], dim=-1).to(device)
                     
         
-def generate_sparse_coo_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to generate nnz random unique COO coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
-    As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-    Currently, for simplicity, this implementation uses the same indices for each batch element.
-    Therefore, the coordinates are unique for each batch element, but not across batch elements.
+# def generate_sparse_coo_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
+#     """Used to generate nnz random unique COO coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
+#     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
+#     Currently, for simplicity, this implementation uses the same indices for each batch element.
+#     Therefore, the coordinates are unique for each batch element, but not across batch elements.
 
-    Args:
-        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
-        nnz (int): Number of elements the generated COO indices represent. This must be less than or equal to the total number of elements in the matrix.
-        upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
-        dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
-        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
+#     Args:
+#         size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
+#         nnz (int): Number of elements the generated COO indices represent. This must be less than or equal to the total number of elements in the matrix.
+#         upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
+#         dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
+#         device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
 
-    Raises:
-        ValueError: Raised if size has less than 2 dimensions.
-        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-        ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
-        ValueError: Raised if nnz is greater than the total number of elements (n * n).
+#     Raises:
+#         ValueError: Raised if size has less than 2 dimensions.
+#         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+#         ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
+#         ValueError: Raised if nnz is greater than the total number of elements (n * n).
 
-    Returns:
-        torch.Tensor: Returns a tensor of shape [ndim, nnz] containing the generated COO coordinates.
-    """
-    if len(size) < 2:
-        raise ValueError("size must have at least 2 dimensions")
-    elif len(size) > 3:
-        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+#     Returns:
+#         torch.Tensor: Returns a tensor of shape [ndim, nnz] containing the generated COO coordinates.
+#     """
+#     if len(size) < 2:
+#         raise ValueError("size must have at least 2 dimensions")
+#     elif len(size) > 3:
+#         raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
 
-    if size[-2] != size[-1]:
-        raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
+#     if size[-2] != size[-1]:
+#         raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
 
-    if nnz > size[-2] * size[-1]:
-        raise ValueError("nnz must be less than or equal to n * n")
+#     if nnz > size[-2] * size[-1]:
+#         raise ValueError("nnz must be less than or equal to n * n")
 
-    unbatched_coo_coordinates = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
-    if len(size) == 2:
-        return unbatched_coo_coordinates
-    else:
-        sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
-        batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
-        return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
+#     unbatched_coo_coordinates = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
+#     if len(size) == 2:
+#         return unbatched_coo_coordinates
+#     else:
+#         sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
+#         batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
+#         return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
     
     
-def _gen_indices_2d_csr_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to generate nnz random unique csr coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
+# def _gen_indices_2d_csr_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
+#     """Used to generate nnz random unique csr coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
     
-    Args:
-        n (int): Number of rows and columns (since it's a square matrix).
-        nnz (int): Number of elements the generated csr indices represent.
-        upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
-        dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
-        device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+#     Args:
+#         n (int): Number of rows and columns (since it's a square matrix).
+#         nnz (int): Number of elements the generated csr indices represent.
+#         upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
+#         dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
+#         device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
 
-    Returns:
-        crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the generated crow_indices.
-        col_indices (torch.Tensor): Tensor of shape [nnz] containing the generated col_indices.
-    """
-    assert nnz <= n * n, "Number of elements (nnz) must be less than or equal to the total number of elements (n * n)."
-    assert n == n, "Number of rows (nr) must be equal to the number of columns (nc) to create a square matrix."
+#     Returns:
+#         crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the generated crow_indices.
+#         col_indices (torch.Tensor): Tensor of shape [nnz] containing the generated col_indices.
+#     """
+#     assert nnz <= n * n, "Number of elements (nnz) must be less than or equal to the total number of elements (n * n)."
+#     assert n == n, "Number of rows (nr) must be equal to the number of columns (nc) to create a square matrix."
     
-    crow_indices = torch.zeros(n+1, dtype=dtype, device=device)
-    col_indices = torch.zeros(nnz, dtype=dtype, device=device)
+#     crow_indices = torch.zeros(n+1, dtype=dtype, device=device)
+#     col_indices = torch.zeros(nnz, dtype=dtype, device=device)
     
-    for i in range(n):
-        if i == n - 1:
-            step = nnz - crow_indices[i]  # If we reach the last step, we set the step size to ensure we reach nnz.
-        else:
-            max_step = min(n-i, nnz - crow_indices[i] - (n - i))
-            step = random.randint(0, max_step+1) if upper else torch.randint(1, max_step+1)
-        crow_indices[i+1] = crow_indices[i] + step
+#     for i in range(n):
+#         if i == n - 1:
+#             step = nnz - crow_indices[i]  # If we reach the last step, we set the step size to ensure we reach nnz.
+#         else:
+#             max_step = min(n-i, nnz - crow_indices[i] - (n - i))
+#             step = random.randint(0, max_step+1) if upper else torch.randint(1, max_step+1)
+#         crow_indices[i+1] = crow_indices[i] + step
         
-        if upper:
-            col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(i+1, i+1+step, device=device)
-        else:
-            col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(0, step, device=device)
+#         if upper:
+#             col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(i+1, i+1+step, device=device)
+#         else:
+#             col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(0, step, device=device)
 
-    return crow_indices, col_indices
+#     return crow_indices, col_indices
 
 
-def generate_sparse_csr_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
-    """Used to generate nnz random unique CSR coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
-    As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-    Currently, for simplicity, this implementation uses the same indices for each batch element.
-    Therefore, the coordinates are unique for each batch element, but not across batch elements.
+# def generate_sparse_csr_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
+#     """Used to generate nnz random unique CSR coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
+#     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
+#     Currently, for simplicity, this implementation uses the same indices for each batch element.
+#     Therefore, the coordinates are unique for each batch element, but not across batch elements.
 
-    Args:
-        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
-        nnz (int): Number of elements the generated CSR indices represent. This must be less than or equal to the total number of elements in the matrix.
-        upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
-        dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
-        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
+#     Args:
+#         size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
+#         nnz (int): Number of elements the generated CSR indices represent. This must be less than or equal to the total number of elements in the matrix.
+#         upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
+#         dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
+#         device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
 
-    Raises:
-        ValueError: Raised if size has less than 2 dimensions.
-        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-        ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
-        ValueError: Raised if nnz is greater than the total number of elements (n * n).
+#     Raises:
+#         ValueError: Raised if size has less than 2 dimensions.
+#         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+#         ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
+#         ValueError: Raised if nnz is greater than the total number of elements (n * n).
 
-    Returns:
-        torch.Tensor: Returns a tuple of tensors (crow_indices, col_indices) representing the generated CSR indices.
-    """
-    if len(size) < 2:
-        raise ValueError("size must have at least 2 dimensions")
-    elif len(size) > 3:
-        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+#     Returns:
+#         torch.Tensor: Returns a tuple of tensors (crow_indices, col_indices) representing the generated CSR indices.
+#     """
+#     if len(size) < 2:
+#         raise ValueError("size must have at least 2 dimensions")
+#     elif len(size) > 3:
+#         raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
 
-    if size[-2] != size[-1]:
-        raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
+#     if size[-2] != size[-1]:
+#         raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
 
-    if nnz > size[-2] * size[-1]:
-        raise ValueError("nnz must be less than or equal to n * n")
+#     if nnz > size[-2] * size[-1]:
+#         raise ValueError("nnz must be less than or equal to n * n")
 
-    crow_indices, col_indices = _gen_indices_2d_csr_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
-    if len(size) == 2:
-        return crow_indices, col_indices
-    else:
-        crow_indices = crow_indices.repeat(size[0], 1)
-        col_indices = col_indices.repeat(size[0], 1)
-        return crow_indices, col_indices
+#     crow_indices, col_indices = _gen_indices_2d_csr_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
+#     if len(size) == 2:
+#         return crow_indices, col_indices
+#     else:
+#         crow_indices = crow_indices.repeat(size[0], 1)
+#         col_indices = col_indices.repeat(size[0], 1)
+#         return crow_indices, col_indices
     
 
 
@@ -329,29 +267,29 @@ def generate_sparse_csr_matrix_indices_strictly_triangular(size, nnz, upper=True
 
 
 
-# unit test and move to contraints
-def is_strictly_triangular(crow_indices, col_indices, upper=True):
-    """Check whether the given crow_indices and col_indices represent strictly upper triangular or strictly lower triangular indices.
+# # unit test and move to contraints
+# def is_strictly_triangular(crow_indices, col_indices, upper=True):
+#     """Check whether the given crow_indices and col_indices represent strictly upper triangular or strictly lower triangular indices.
     
-    Args:
-        crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the crow_indices.
-        col_indices (torch.Tensor): Tensor of shape [nnz] containing the col_indices.
-        upper (bool, optional): Flag indicating whether to check for strictly upper triangular indices. Defaults to True.
+#     Args:
+#         crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the crow_indices.
+#         col_indices (torch.Tensor): Tensor of shape [nnz] containing the col_indices.
+#         upper (bool, optional): Flag indicating whether to check for strictly upper triangular indices. Defaults to True.
     
-    Returns:
-        bool: True if the indices are strictly upper triangular or strictly lower triangular, False otherwise.
-    """
-    assert crow_indices.dim() == 1 and col_indices.dim() == 1, "Input tensors must be 1-dimensional."
-    assert crow_indices.size(0) == crow_indices[-1], "crow_indices must represent a valid compressed sparse row structure."
-    assert col_indices.size(0) == crow_indices[-1], "col_indices must have the same length as crow_indices[-1]."
+#     Returns:
+#         bool: True if the indices are strictly upper triangular or strictly lower triangular, False otherwise.
+#     """
+#     assert crow_indices.dim() == 1 and col_indices.dim() == 1, "Input tensors must be 1-dimensional."
+#     assert crow_indices.size(0) == crow_indices[-1], "crow_indices must represent a valid compressed sparse row structure."
+#     assert col_indices.size(0) == crow_indices[-1], "col_indices must have the same length as crow_indices[-1]."
     
-    if upper:
-        for i in range(crow_indices.size(0) - 1):
-            if (col_indices[crow_indices[i]:crow_indices[i+1]] <= i).any():
-                return False
-        return True
-    else:
-        for i in range(crow_indices.size(0) - 1):
-            if (col_indices[crow_indices[i]:crow_indices[i+1]] >= i+1).any():
-                return False
-        return True
+#     if upper:
+#         for i in range(crow_indices.size(0) - 1):
+#             if (col_indices[crow_indices[i]:crow_indices[i+1]] <= i).any():
+#                 return False
+#         return True
+#     else:
+#         for i in range(crow_indices.size(0) - 1):
+#             if (col_indices[crow_indices[i]:crow_indices[i+1]] >= i+1).any():
+#                 return False
+#         return True

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -9,7 +9,7 @@ NOTE: Sparse CSR The index tensors crow_indices and col_indices should have elem
 import warnings
 import torch
 import random
-from torchsparsegradutils.utils.utils import _compress_row_indices, covert_coo_to_csr_indices_values
+from torchsparsegradutils.utils.utils import _compress_row_indices, convert_coo_to_csr_indices_values
 
 def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Generates nnz random unique coordinates in COO format.
@@ -111,7 +111,7 @@ def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, v
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
     coo_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
-    crow_indices, col_indices, _ = covert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
+    crow_indices, col_indices, _ = convert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)
@@ -232,7 +232,7 @@ def generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, *, upper=Tr
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
     coo_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
-    crow_indices, col_indices, _ = covert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
+    crow_indices, col_indices, _ = convert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -38,23 +38,23 @@ def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("
     
     
 def generate_random_sparse_coo_matrix(size, nnz, *, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
-    """Generates a random sparse COO matrix.
+    """Generates a random sparse COO matrix of the specified size and number of non-zero elements.
 
     Args:
-        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((nr, nc)) for a single batch or ((b), nr, nc) for a batched matrix, where (b) represents the number of batch elements.
-        nnz (int): Number of elements the generated COO indices represent. This must be less than or equal to the total number of elements in the matrix.
-        indices_dtype (torch.dtype, optional): Data type of the generated indices tensor. Defaults to torch.int64.
-        values_dtype (torch.dtype, optional): Data type of the generated values tensor. Defaults to torch.float32.
+        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either (num_rows, num_cols) for a unbatched matrix or (batch_size, num_rows, num_cols) for a batched matrix.
+        nnz (int): Number of non-zero values in sparse matrix (number of sparse elements). This must be less than or equal to the total number of elements in the matrix.
+        indices_dtype (torch.dtype, optional): Data type for indices of sparse tensor. Defaults to torch.int64.
+        values_dtype (torch.dtype, optional): Data type for values of sparse tensor. Defaults to torch.float32.
         device (torch.device, optional): Device to generate the tensor on. Defaults to torch.device("cpu").
 
     Raises:
         ValueError: Raised if size has less than 2 dimensions.
         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-        ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
-        UserWarning: Raised when `indices_dtype` is not `torch.int64`, as this is the only indices dtype supported for sparse COO tensors. The index type will be converted to `torch.int64`.
+        ValueError: Raised if nnz is greater than the total number of elements (size[-2] * size[-3]).
+        UserWarning: Raised when `indices_dtype` is not `torch.int64`, as this is the only indices dtype supported for sparse COO tensors. Any other index dtype will be converted to `torch.int64`.
 
     Returns:
-        torch.Tensor: Returns a sparse COO tensor of shape size with nnz elements.
+        torch.Tensor: Returns a sparse COO tensor of shape size with nnz non-zero elements.
     """
    
     if len(size) < 2:
@@ -73,8 +73,7 @@ def generate_random_sparse_coo_matrix(size, nnz, *, indices_dtype=torch.int64, v
         values = torch.rand(nnz, dtype=values_dtype, device=device)
     else:
         sparse_dim_indices = torch.cat([_gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device) for _ in range(size[0])], dim=-1)
-        # batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
-        batch_dim_indices = batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat_interleave(nnz).unsqueeze(0)
+        batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat_interleave(nnz).unsqueeze(0)
         coo_indices = torch.cat([batch_dim_indices, sparse_dim_indices])
         values = torch.rand(nnz*size[0], dtype=values_dtype, device=device)        
 
@@ -82,23 +81,23 @@ def generate_random_sparse_coo_matrix(size, nnz, *, indices_dtype=torch.int64, v
 
 
 def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
-    """Generates random unique CSR coordinates for a batched sparse matrix specified by size ((b), nr, nc).
+    """Generates a random sparse CSR matrix of the specified size and number of non-zero elements.
 
     Args:
-        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((nr, nc)) for a single batch or ((b), nr, nc) for a batched matrix, where (b) represents the number of batch elements.
-        nnz (int): Number of elements the generated CSR indices represent. This must be less than or equal to the total number of elements in the matrix.
-        indices_dtype (torch.dtype, optional): Data type of the generated indices tensor. Defaults to torch.int64.
-        values_dtype (torch.dtype, optional): Data type of the generated values tensor. Defaults to torch.float32.
+        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either (num_rows, num_cols) for a unbatched matrix or (batch_size, num_rows, num_cols) for a batched matrix.
+        nnz (int): Number of non-zero values in sparse matrix (number of sparse elements). This must be less than or equal to the total number of elements in the matrix.
+        indices_dtype (torch.dtype, optional): Data type for indices of sparse tensor. Defaults to torch.int64.
+        values_dtype (torch.dtype, optional): Data type for values of sparse tensor. Defaults to torch.float32.
         device (torch.device, optional): Device to generate the tensor on. Defaults to torch.device("cpu").
 
     Raises:
         ValueError: Raised if size has less than 2 dimensions.
         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-        ValueError: Raised if nnz is greater than the total number of elements (nr * nc).
+        ValueError: Raised if nnz is greater than the total number of elements (size[-2] * size[-3]).
         UserWarning: Raised when `indices_dtype` has a bit depth less than `torch.int32`, as this is not recommended.
 
     Returns:
-        torch.Tensor: Returns a sparse CSR tensor of shape size with nnz elements.
+        torch.Tensor: Returns a sparse CSR tensor of shape size with nnz non-zero elements.
     """
     if len(size) < 2:
         raise ValueError("size must have at least 2 dimensions")
@@ -108,7 +107,7 @@ def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, v
     if nnz > size[-2] * size[-1]:
         raise ValueError("nnz must be less than or equal to nr * nc")
     
-    if (indices_dtype != torch.int64) or (indices_dtype != torch.int32):
+    if (indices_dtype != torch.int64) and (indices_dtype != torch.int32):
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
     row_indices, col_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
@@ -124,150 +123,125 @@ def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, v
     return torch.sparse_csr_tensor(crow_indices, col_indices, values, size, device=device)
 
 
-# # Square strictly Triangular:
+# Square strictly Triangular:
 
-# def _gen_indices_2d_coo_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
-#     """Used to generate nnz random unique COO coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
+def _gen_indices_2d_coo_strictly_tri(n, nnz, *, upper=True, dtype=torch.int64, device=torch.device("cpu")):
+    """Generates nnz random unique COO coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
 
-#     Args:
-#         n (int): Size of the square matrix (number of rows and columns).
-#         nnz (int): Number of elements the generated COO indices represent.
-#         upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
-#         dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
-#         device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+    Args:
+        n (int): Size of the square matrix (number of rows and columns).
+        nnz (int): Number of elements the generated COO indices represent.
+        upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
+        dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
+        device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
 
-#     Returns:
-#         indices (torch.Tensor): Tensor of shape [2, nnz] containing the generated COO indices.
-#     """
-#     assert nnz <= n * (n - 1) // 2, "Number of elements (nnz) must be less than or equal to the total number of elements (n * (n - 1) // 2)."
+    Returns:
+        torch.Tensor: Tensor of shape [2, nnz] containing the generated COO indices.
+    """
+    assert nnz <= n * (n - 1) // 2, "Number of elements (nnz) must be less than or equal to the total number of elements (n * (n - 1) // 2)."
 
-#     coordinates = set()
-#     while True:
-#             r, c = random.randrange(n), random.randrange(n)
-#             if (r < c and upper) or (r > c and not upper):
-#                 coordinates.add((r, c))
-#             if len(coordinates) == nnz:
-#                 return torch.stack([torch.tensor(co) for co in coordinates], dim=-1).to(device)
+    coordinates = set()
+    while True:
+        r, c = random.randrange(n), random.randrange(n)
+        if (r < c and upper) or (r > c and not upper):
+            coordinates.add((r, c))
+        if len(coordinates) == nnz:
+            return torch.stack([torch.tensor(co, dtype=dtype, device=device) for co in coordinates], dim=-1).to(device)
                     
         
-# def generate_sparse_coo_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
-#     """Used to generate nnz random unique COO coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
-#     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-#     Currently, for simplicity, this implementation uses the same indices for each batch element.
-#     Therefore, the coordinates are unique for each batch element, but not across batch elements.
+def generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, *, upper=True, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
+    """Generates a random sparse COO square matrix with strictly upper or lower triangular coordinates.
 
-#     Args:
-#         size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
-#         nnz (int): Number of elements the generated COO indices represent. This must be less than or equal to the total number of elements in the matrix.
-#         upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
-#         dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
-#         device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
+    Args:
+        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either (num_rows, num_cols) for a unbatched matrix or (batch_size, num_rows, num_cols) for a batched matrix. The number of rows and columns must be equal.
+        nnz (int): Number of non-zero values in sparse matrix (number of sparse elements). nnz must be less than or equal to (n * n-1)/2, where n is the number of rows or columns. # TODO: per batch element...
+        upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
+        indices_dtype (torch.dtype, optional): Data type for indices of sparse tensor. Defaults to torch.int64.
+        values_dtype (torch.dtype, optional): Data type for values of sparse tensor. Defaults to torch.float32.
+        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
 
-#     Raises:
-#         ValueError: Raised if size has less than 2 dimensions.
-#         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-#         ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
-#         ValueError: Raised if nnz is greater than the total number of elements (n * n).
+    Raises:
+        ValueError: Raised if size has less than 2 dimensions.
+        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+        ValueError: Raised if size is not a square matrix (n, n) or batched square matrix (b, n, n).
+        ValueError: Raised if nnz is greater than (n * n-1)/2, where n is the number of rows or columns.
+        UserWarning: Raised when `indices_dtype` is not `torch.int64`, as this is the only indices dtype supported for sparse COO tensors. Any other index dtype will be converted to `torch.int64`.
 
-#     Returns:
-#         torch.Tensor: Returns a tensor of shape [ndim, nnz] containing the generated COO coordinates.
-#     """
-#     if len(size) < 2:
-#         raise ValueError("size must have at least 2 dimensions")
-#     elif len(size) > 3:
-#         raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+    Returns:
+        torch.Tensor: Returns a square strictly upper or lower sparse COO tensor of shape size with nnz non-zero elements.
+    """
+    if len(size) < 2:
+        raise ValueError("size must have at least 2 dimensions")
+    elif len(size) > 3:
+        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
 
-#     if size[-2] != size[-1]:
-#         raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
+    if size[-2] != size[-1]:
+        raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
 
-#     if nnz > size[-2] * size[-1]:
-#         raise ValueError("nnz must be less than or equal to n * n")
-
-#     unbatched_coo_coordinates = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
-#     if len(size) == 2:
-#         return unbatched_coo_coordinates
-#     else:
-#         sparse_dim_coordinates = torch.cat([unbatched_coo_coordinates] * size[0], dim=-1)
-#         batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
-#         return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
+    if nnz > size[-2] * (size[-2] - 1) // 2:
+        raise ValueError("nnz must be less than or equal to (n * n-1)/2, where n is the number of rows or columns")
     
-    
-# def _gen_indices_2d_csr_strictly_tri(n, nnz, upper=True, *, dtype=torch.int64, device=torch.device("cpu")):
-#     """Used to generate nnz random unique csr coordinates for a square matrix with either strictly lower triangular or strictly upper triangular coordinates.
-    
-#     Args:
-#         n (int): Number of rows and columns (since it's a square matrix).
-#         nnz (int): Number of elements the generated csr indices represent.
-#         upper (bool, optional): Flag indicating whether to generate strictly upper triangular coordinates. Defaults to True.
-#         dtype (torch.dtype, optional): Data type of the tensors. Defaults to torch.int64.
-#         device (torch.device, optional): Device to generate coordinates on. Defaults to torch.device("cpu").
+    if indices_dtype != torch.int64:
+        warnings.warn(f"Only indices of type torch.int64 supported for sparse COO tensors. Indices of type {indices_dtype} will be cast to torch.int64.", UserWarning)
 
-#     Returns:
-#         crow_indices (torch.Tensor): Tensor of shape [nr+1] containing the generated crow_indices.
-#         col_indices (torch.Tensor): Tensor of shape [nnz] containing the generated col_indices.
-#     """
-#     assert nnz <= n * n, "Number of elements (nnz) must be less than or equal to the total number of elements (n * n)."
-#     assert n == n, "Number of rows (nr) must be equal to the number of columns (nc) to create a square matrix."
+    if len(size) == 2:
+        coo_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
+        values = torch.rand(nnz, dtype=values_dtype, device=device)
+    else:
+        sparse_dim_indices = torch.cat([_gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device) for _ in range(size[0])], dim=-1)
+        batch_dim_indices = batch_dim_indices = torch.arange(size[0], dtype=indices_dtype, device=device).repeat_interleave(nnz).unsqueeze(0)
+        coo_indices = torch.cat([batch_dim_indices, sparse_dim_indices])
+        values = torch.rand(nnz*size[0], dtype=values_dtype, device=device)        
+
+    return torch.sparse_coo_tensor(coo_indices, values, size, device=device).coalesce()
     
-#     crow_indices = torch.zeros(n+1, dtype=dtype, device=device)
-#     col_indices = torch.zeros(nnz, dtype=dtype, device=device)
+
+def generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, *, upper=True, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
+    """Generates a random sparse CSR square matrix with strictly upper or lower triangular coordinates.
+
+    Args:
+        size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either (num_rows, num_cols) for a unbatched matrix or (batch_size, num_rows, num_cols) for a batched matrix. The number of rows and columns must be equal.
+        nnz (int): Number of non-zero values in sparse matrix (number of sparse elements). nnz must be less than or equal to (n * n-1)/2, where n is the number of rows or columns.
+        upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
+        indices_dtype (torch.dtype, optional): Data type for indices of sparse tensor. Defaults to torch.int64.
+        values_dtype (torch.dtype, optional): Data type for values of sparse tensor. Defaults to torch.float32.
+        device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
+
+    Raises:
+        ValueError: Raised if size has less than 2 dimensions.
+        ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
+        ValueError: Raised if size is not a square matrix (n, n) or batched square matrix (b, n, n).
+        ValueError: Raised if nnz is greater than (n * n-1)/2, where n is the number of rows or columns.
+        UserWarning: Raised when `indices_dtype` has a bit depth less than `torch.int32`, as this is not recommended.
+
+    Returns:
+        torch.Tensor: Returns a square strictly upper or lower sparse CSR tensor of shape size with nnz non-zero elements.
+    """
+    if len(size) < 2:
+        raise ValueError("size must have at least 2 dimensions")
+    elif len(size) > 3:
+        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+
+    if size[-2] != size[-1]:
+        raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
+
+    if nnz > size[-2] * (size[-2] - 1) // 2:
+        raise ValueError("nnz must be less than or equal to (n * n-1)/2, where n is the number of rows or columns")
     
-#     for i in range(n):
-#         if i == n - 1:
-#             step = nnz - crow_indices[i]  # If we reach the last step, we set the step size to ensure we reach nnz.
-#         else:
-#             max_step = min(n-i, nnz - crow_indices[i] - (n - i))
-#             step = random.randint(0, max_step+1) if upper else torch.randint(1, max_step+1)
-#         crow_indices[i+1] = crow_indices[i] + step
+    if (indices_dtype != torch.int64) and (indices_dtype != torch.int32):
+        warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
+
+    row_indices, col_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
+    crow_indices = compress_row_indices(row_indices, size[-2])
+    
+    if len(size) == 2:
+        values = torch.rand(nnz, dtype=values_dtype, device=device)
+    else:
+        crow_indices = crow_indices.repeat(size[0], 1)
+        col_indices = col_indices.repeat(size[0], 1)
+        values = torch.rand(nnz*size[0], dtype=values_dtype, device=device)
         
-#         if upper:
-#             col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(i+1, i+1+step, device=device)
-#         else:
-#             col_indices[crow_indices[i]:crow_indices[i+1]] = torch.arange(0, step, device=device)
-
-#     return crow_indices, col_indices
-
-
-# def generate_sparse_csr_matrix_indices_strictly_triangular(size, nnz, upper=True, dtype=torch.int64, device=torch.device("cpu")):
-#     """Used to generate nnz random unique CSR coordinates for sparse strictly lower triangular or strictly upper triangular matrices with shape ((b), n, n).
-#     As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
-#     Currently, for simplicity, this implementation uses the same indices for each batch element.
-#     Therefore, the coordinates are unique for each batch element, but not across batch elements.
-
-#     Args:
-#         size (tuple): Tuple specifying the dimensions of the batched sparse matrix. The size can be either ((n, n)) for a single batch or ((b), n, n) for a batched matrix, where (b) represents the number of batch elements.
-#         nnz (int): Number of elements the generated CSR indices represent. This must be less than or equal to the total number of elements in the matrix.
-#         upper (bool, optional): If True, generates strictly upper triangular indices. If False, generates strictly lower triangular indices. Defaults to True.
-#         dtype (torch.dtype, optional): Data type of the generated tensor. Defaults to torch.int64.
-#         device (torch.device, optional): Device to generate the coordinates on. Defaults to torch.device("cpu").
-
-#     Raises:
-#         ValueError: Raised if size has less than 2 dimensions.
-#         ValueError: Raised if size has more than 3 dimensions, as this implementation only supports 1 batch dimension.
-#         ValueError: Raise if size is not a square matrix (n, n) or batched square matrix (b, n, n).
-#         ValueError: Raised if nnz is greater than the total number of elements (n * n).
-
-#     Returns:
-#         torch.Tensor: Returns a tuple of tensors (crow_indices, col_indices) representing the generated CSR indices.
-#     """
-#     if len(size) < 2:
-#         raise ValueError("size must have at least 2 dimensions")
-#     elif len(size) > 3:
-#         raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
-
-#     if size[-2] != size[-1]:
-#         raise ValueError("size must be a square matrix (n, n) or batched square matrix (b, n, n)")
-
-#     if nnz > size[-2] * size[-1]:
-#         raise ValueError("nnz must be less than or equal to n * n")
-
-#     crow_indices, col_indices = _gen_indices_2d_csr_strictly_tri(size[-2], nnz, upper=upper, dtype=dtype, device=device)
-#     if len(size) == 2:
-#         return crow_indices, col_indices
-#     else:
-#         crow_indices = crow_indices.repeat(size[0], 1)
-#         col_indices = col_indices.repeat(size[0], 1)
-#         return crow_indices, col_indices
+    return torch.sparse_csr_tensor(crow_indices, col_indices, values, size, device=device)
     
 
 

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -1,0 +1,57 @@
+"""
+utility functions for generating random sparse matrices
+
+NOTE: sparse COO tensors have indices tensor of size (ndim, nse) and with element type torch.int64
+
+NOTE: Sparse CSR The index tensors crow_indices and col_indices should have element type either torch.int64 (default) or torch.int32. 
+If you want to use MKL-enabled matrix operations, use torch.int32. 
+This is as a result of the default linking of pytorch being with MKL LP64, which uses 32 bit integer indexing
+"""
+
+import torch
+from random import randrange
+
+def _gencoordinates_2d(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
+    """Used to genererate nnz random unique coordinates
+    
+    Args:
+        nr (int): number of rows
+        nc (int): number of columns
+        nnz (int): number of pairs of coordinates to generate
+        device (torch.device, optional): device to generate coordinates on. Defaults to torch.device("cpu").
+
+    Returns:
+        torch.tensor: tensor of shape [2, nnz] containing the generated coordinates
+    """
+    coordinates = set()
+    while True:
+        r, c = randrange(nr), randrange(nc)
+        coordinates.add((r, c))
+        if len(coordinates) == nnz:
+            return torch.stack([torch.tensor(co, dtype=dtype) for co in coordinates], dim=-1).to(device)
+
+
+def gencoordinates(size, nnz, *, layout=torch.sparse_coo, dtype=torch.int64, device=torch.device("cpu")):
+    """
+    Used to genererate nnz random unique COO or CSR coordinates for sparse matrix specified by size
+    As per the PyTorch documentation, batched sparse matrices must have the same number of elements (nnz) per batch element.
+    Currently, for simplicity, this implementation uses the same indices for each batch element.
+    Therefore, the coordinates are unique for each bathc element, but not across batch elements.
+    """
+    if len(size) < 2:
+        raise ValueError("size must have at least 2 dimensions")
+    elif len(size) > 3:
+        raise ValueError("size must have at most 3 dimensions, as this implementation only supports 1 batch dimension")
+            
+    coo_coordinates = _gencoordinates_2d(size[-2], size[-1], nnz, dtype=dtype, device=device)
+    
+    if layout == torch.sparse_coo:
+        if len(size) == 2:
+            return coo_coordinates
+        else:
+            sparse_dim_coordinates = torch.cat([coo_coordinates] * size[0], dim=-1)
+            batch_dim_coordinates = torch.arange(size[0], dtype=dtype, device=device).repeat(nnz).flatten().unsqueeze(0)
+            return torch.cat([batch_dim_coordinates, sparse_dim_coordinates])
+    
+    
+    

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -9,7 +9,7 @@ NOTE: Sparse CSR The index tensors crow_indices and col_indices should have elem
 import warnings
 import torch
 import random
-from torchsparsegradutils.utils.utils import _compress_row_indices
+from torchsparsegradutils.utils.utils import _compress_row_indices, covert_coo_to_csr_indices_values
 
 def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Generates nnz random unique coordinates in COO format.
@@ -110,8 +110,8 @@ def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, v
     if (indices_dtype != torch.int64) and (indices_dtype != torch.int32):
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
-    row_indices, col_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
-    crow_indices = _compress_row_indices(row_indices, size[-2])
+    coo_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
+    crow_indices, col_indices, _ = covert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)
@@ -231,8 +231,8 @@ def generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, *, upper=Tr
     if (indices_dtype != torch.int64) and (indices_dtype != torch.int32):
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
-    row_indices, col_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
-    crow_indices = _compress_row_indices(row_indices, size[-2])
+    coo_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
+    crow_indices, col_indices, _ = covert_coo_to_csr_indices_values(coo_indices, size[-2], values=None)
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -9,7 +9,7 @@ NOTE: Sparse CSR The index tensors crow_indices and col_indices should have elem
 import warnings
 import torch
 import random
-from torchsparsegradutils.utils.utils import compress_row_indices
+from torchsparsegradutils.utils.utils import _compress_row_indices
 
 def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Generates nnz random unique coordinates in COO format.
@@ -111,7 +111,7 @@ def generate_random_sparse_csr_matrix(size, nnz, *, indices_dtype=torch.int64, v
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
     row_indices, col_indices = _gen_indices_2d_coo(size[-2], size[-1], nnz, dtype=indices_dtype, device=device)
-    crow_indices = compress_row_indices(row_indices, size[-2])
+    crow_indices = _compress_row_indices(row_indices, size[-2])
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)
@@ -232,7 +232,7 @@ def generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, *, upper=Tr
         warnings.warn(f"A bit depth of less than torch.int32 is not recommended for sparse CSR tensors", UserWarning)
 
     row_indices, col_indices = _gen_indices_2d_coo_strictly_tri(size[-2], nnz, upper=upper, dtype=indices_dtype, device=device)
-    crow_indices = compress_row_indices(row_indices, size[-2])
+    crow_indices = _compress_row_indices(row_indices, size[-2])
     
     if len(size) == 2:
         values = torch.rand(nnz, dtype=values_dtype, device=device)

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -3,8 +3,7 @@ import torch
 
 def _sort_coo_indices(indices):
     """
-    Sorts COO (Coordinate List Format) indices in ascending order and returns a permutation tensor that indicates
-    the indices in the original data that result in a sorted tensor.
+    Sorts COO (Coordinate List Format) indices in ascending order and returns a permutation tensor that indicates the indices in the original data that result in a sorted tensor.
 
     This function can support both unbatched and batched COO indices, and essentially performs the same operation as .coalesce() called on a COO tensor.
     The advantage is that COO coordinates can be sorted prior to conversion to CSR, without having to use the torch.sparse_coo_tensor object which only supports int64 indices.
@@ -37,45 +36,67 @@ def _compress_row_indices(row_indices, num_rows):
 
 
     # Compute the cumulative sum of counts to get CSR indices
-    crow_indices = torch.cat([torch.zeros(1, dtype=row_indices.dtype, device=counts.device), counts.cumsum(dim=0, dtype=row_indices.dtype)])
+    crow_indices = torch.cat([torch.zeros(1, dtype=row_indices.dtype, device=counts.device), counts.cumsum_(dim=0)])
 
 
     return crow_indices
 
 
-# TODO: add support for batched
-def covert_coo_to_csr_indices_values(coo_indices, num_rows, values=None):
+def convert_coo_to_csr_indices_values(coo_indices, num_rows, values=None):
     """Converts COO row and column indices to CSR crow and col indices.
+    Supports batched indices, which would have shape [3, nnz]. Or, [2, nnz] for unbatched indices.
     This function sorts the row and column indices (similar to torch.sparse_coo_tensor.coalesce()) and then compresses the row indices to CSR crow indices.
-    If values are provided, the tensor is permuted according to the sorted COO indices.
+    If values are provided, the values tensor is permuted according to the sorted COO indices.
     If no values are provided, the permutation indices are returned.
 
 
     Args:
-        row_indices (torch.Tensor): Tensor of COO row indices.
-        col_indices (torch.Tensor): Tensor of COO column indices.
+        coo_indices (torch.Tensor): Tensor of COO indices
         num_rows (int): Number of rows in the matrix.
 
 
     Returns:
         torch.Tensor: Compressed CSR crow indices.
-        torch.Tensor: Compressed CSR col indices.
-        torch.Tensor: Permutation indices from sorting the col indices. Or permuted values if values are provided.
+        torch.Tensor: CSR Col indices.
+        torch.Tensor: Permutation indices from sorting COO indices. Or permuted values if values are provided.
     """
+    if coo_indices.shape[0] < 2:
+        raise ValueError(f"Indices tensor must have at least 2 rows (row and column indices). Got {coo_indices.shape[0]} rows.")
+    elif coo_indices.shape[0] > 3:
+        raise ValueError(f"Current implementation only supports single batch diomension, therefore indices tensor must have at most 3 rows (batch, row and column indices). Got {coo_indices.shape[0]} rows.")
+    
+    if coo_indices[-2].max() >= num_rows:
+        raise ValueError(f"Row indices must be less than num_rows ({num_rows}). Got max row index {coo_indices[-2].max()}")
+    
+    if values != None and values.shape[0] != coo_indices.shape[1]:
+        raise ValueError(f"Number of values ({values.shape[0]}) does not match number of indices ({coo_indices.shape[1]})")
+    
     coo_indices, permutation = _sort_coo_indices(coo_indices)
-    row_indices, col_indices = coo_indices
-    crow_indices = _compress_row_indices(row_indices, num_rows)
 
-    if values == None:
-        return crow_indices, col_indices, permutation
+    if coo_indices.shape[0] == 2:
+        row_indices, col_indices = coo_indices
+        crow_indices = _compress_row_indices(row_indices, num_rows)
+        
+        values = values[permutation] if values is not None else permutation
+        
     else:
-        return crow_indices, col_indices, values[permutation]
+        batch_indices, row_indices, col_indices = coo_indices
+        crow_indices = torch.cat([_compress_row_indices(row_indices[batch_indices == batch], num_rows) for batch in torch.unique(batch_indices)])
+        num_batches = torch.unique(batch_indices).shape[0]
+        
+        crow_indices = crow_indices.reshape(num_batches, -1)
+        col_indices = col_indices.reshape(num_batches, -1)
+        
+        values = values[permutation] if values is not None else permutation
+        
+        values = values.reshape(num_batches, -1)
+        
+    return crow_indices, col_indices, values
 
 
-# TODO: add support for batched
+
 def convert_coo_to_csr(sparse_coo_tensor):
-    """Converts a COO sparse tensor to CSR format.
-
+    """Converts a COO sparse tensor to CSR format. COO tensor can have optional single leading batch dimension.
 
     Args:
         sparse_coo_tensor (torch.Tensor): COO sparse tensor.
@@ -85,14 +106,14 @@ def convert_coo_to_csr(sparse_coo_tensor):
         torch.Tensor: CSR sparse tensor.
     """
     if sparse_coo_tensor.layout == torch.sparse_coo:
-        crow_indices, col_indices, values = covert_coo_to_csr_indices_values(sparse_coo_tensor.indices(), sparse_coo_tensor.size()[0], sparse_coo_tensor.values())
+        crow_indices, col_indices, values = convert_coo_to_csr_indices_values(sparse_coo_tensor.indices(), sparse_coo_tensor.size()[-2], sparse_coo_tensor.values())
         return torch.sparse_csr_tensor(crow_indices, col_indices, values, sparse_coo_tensor.size())
     else:
         raise ValueError(f"Unsupported layout: {sparse_coo_tensor.layout}")
    
 
 
-def demcompress_crow_indices(crow_indices, num_rows):
+def _demcompress_crow_indices(crow_indices, num_rows):
     """Decompresses CSR crow indices to COO row indices.
 
 

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -1,11 +1,14 @@
 import torch
 
-def compress_row_indices(row_indices, num_rows):
+
+def _compress_row_indices(row_indices, num_rows):
     """Compresses COO row indices to CSR crow indices.
+
 
     Args:
         row_indices (torch.Tensor): Tensor of COO row indices.
         num_rows (int): Number of rows in the matrix.
+
 
     Returns:
         torch.Tensor: Compressed CSR crow indices.
@@ -13,25 +16,80 @@ def compress_row_indices(row_indices, num_rows):
     # Compute the number of non-zero elements in each row
     counts = torch.bincount(row_indices, minlength=num_rows).to(row_indices.dtype)
 
+
     # Compute the cumulative sum of counts to get CSR indices
     crow_indices = torch.cat([torch.zeros(1, dtype=row_indices.dtype, device=counts.device), counts.cumsum(dim=0, dtype=row_indices.dtype)])
 
+
     return crow_indices
+
+
+# TODO: add support for batched
+def covert_coo_to_csr_indices_values(coo_indices, num_rows, values=None):
+    """Converts COO row and column indices to CSR crow and col indices.
+    This function compressed the row indices and sorts the column indices.
+    If values are provided, the tensor is permuted according to the sorted column indices.
+    If no values are provided, the permutation indices are returned.
+
+
+    Args:
+        row_indices (torch.Tensor): Tensor of COO row indices.
+        col_indices (torch.Tensor): Tensor of COO column indices.
+        num_rows (int): Number of rows in the matrix.
+
+
+    Returns:
+        torch.Tensor: Compressed CSR crow indices.
+        torch.Tensor: Compressed CSR col indices.
+        torch.Tensor: Permutation indices from sorting the col indices. Or permuted values if values are provided.
+    """
+    row_indices, col_indices = coo_indices
+    crow_indices = _compress_row_indices(row_indices, num_rows)
+    return crow_indices, col_indices, values
+
+    # col_indices, permutation = torch.sort(col_indices)
+   
+    # if values == None:
+    #     return crow_indices, col_indices, permutation
+    # else:
+    #     return crow_indices, col_indices, values[permutation]
+
+
+# TODO: add support for batched
+def convert_coo_to_csr(sparse_coo_tensor):
+    """Converts a COO sparse tensor to CSR format.
+
+
+    Args:
+        sparse_coo_tensor (torch.Tensor): COO sparse tensor.
+
+
+    Returns:
+        torch.Tensor: CSR sparse tensor.
+    """
+    if sparse_coo_tensor.layout == torch.sparse_coo:
+        crow_indices, col_indices, values = covert_coo_to_csr_indices_values(sparse_coo_tensor.indices(), sparse_coo_tensor.size()[0], sparse_coo_tensor.values())
+        return torch.sparse_csr_tensor(crow_indices, col_indices, values, sparse_coo_tensor.size())
+    else:
+        raise ValueError(f"Unsupported layout: {sparse_coo_tensor.layout}")
+   
 
 
 def demcompress_crow_indices(crow_indices, num_rows):
     """Decompresses CSR crow indices to COO row indices.
 
+
     Args:
         csr_crow_indices (torch.Tensor): Tensor of CSR crow indices.
         num_rows (int): Number of rows in the matrix.
 
+
     Returns:
         torch.Tensor: Decompressed COO row indices.
     """
-    
+   
     row_indices = torch.repeat_interleave(
                 torch.arange(num_rows, dtype=crow_indices.dtype, device=crow_indices.device), crow_indices[1:] - crow_indices[:-1]
             )
-    
+   
     return row_indices

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -1,0 +1,35 @@
+import torch
+
+def compress_row_indices(row_indices, num_rows):
+    """Compresses COO row indices to CSR crow indices.
+
+    Args:
+        coo_row_indices (torch.Tensor): Tensor of COO row indices.
+        num_rows (int): Number of rows in the matrix.
+
+    Returns:
+        torch.Tensor: Compressed CSR crow indices.
+    """
+    crow_indices = torch.zeros(num_rows + 1, dtype=row_indices.dtype, device=row_indices.device)
+    torch.bincount(row_indices, minlength=num_rows, out=crow_indices[1:])
+    torch.cumsum(crow_indices[:-1], out=crow_indices[:-1])
+
+    return crow_indices
+
+
+def demcompress_crow_indices(crow_indices, num_rows):
+    """Decompresses CSR crow indices to COO row indices.
+
+    Args:
+        csr_crow_indices (torch.Tensor): Tensor of CSR crow indices.
+        num_rows (int): Number of rows in the matrix.
+
+    Returns:
+        torch.Tensor: Decompressed COO row indices.
+    """
+    
+    row_indices = torch.repeat_interleave(
+                torch.arange(num_rows, dtype=crow_indices.dtype, device=crow_indices.device), crow_indices[1:] - crow_indices[:-1]
+            )
+    
+    return row_indices

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -16,7 +16,7 @@ def _sort_coo_indices(indices):
         torch.Tensor: A permutation tensor that contains the indices in the original tensor that give the sorted tensor.
     """
     indices_sorted, permutation = torch.unique(indices, dim=-1, sorted=True, return_inverse=True)
-    return indices_sorted, torch.argsort(permutation)
+    return indices_sorted.contiguous(), torch.argsort(permutation)
 
 
 def _compress_row_indices(row_indices, num_rows):

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -10,9 +10,11 @@ def compress_row_indices(row_indices, num_rows):
     Returns:
         torch.Tensor: Compressed CSR crow indices.
     """
-    counts = torch.bincount(row_indices)
-    crow_indices = torch.zeros(num_rows + 1, dtype=row_indices.dtype, device=row_indices.device)
-    crow_indices[1:] = torch.cumsum(counts, dim=0)
+    # Compute the number of non-zero elements in each row
+    counts = torch.bincount(row_indices, minlength=num_rows).to(row_indices.dtype)
+
+    # Compute the cumulative sum of counts to get CSR indices
+    crow_indices = torch.cat([torch.zeros(1, dtype=row_indices.dtype, device=counts.device), counts.cumsum(dim=0, dtype=row_indices.dtype)])
 
     return crow_indices
 

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -4,15 +4,15 @@ def compress_row_indices(row_indices, num_rows):
     """Compresses COO row indices to CSR crow indices.
 
     Args:
-        coo_row_indices (torch.Tensor): Tensor of COO row indices.
+        row_indices (torch.Tensor): Tensor of COO row indices.
         num_rows (int): Number of rows in the matrix.
 
     Returns:
         torch.Tensor: Compressed CSR crow indices.
     """
+    counts = torch.bincount(row_indices)
     crow_indices = torch.zeros(num_rows + 1, dtype=row_indices.dtype, device=row_indices.device)
-    torch.bincount(row_indices, minlength=num_rows, out=crow_indices[1:])
-    torch.cumsum(crow_indices[:-1], out=crow_indices[:-1])
+    crow_indices[1:] = torch.cumsum(counts, dim=0)
 
     return crow_indices
 


### PR DESCRIPTION
Solve issue #35 

Utility functions added for generation of unbatched and batched:

- Random sparse COO matrix
- Random sparse CSR matrix
- Random strictly upper/lower triangular COO matrix
- Random strictly upper/lower triangular CSR matrix

These are intended to be primarily used for unit testing, particularly for the batched sparse mm and batched triangular solving. But, they may be useful in other contexts.

Additionally, the following basic utility functions were added, for unbatched and batched sparse tensors:

- Convert COO indices and values to CSR indices and values (without creating sparse_coo_matrix)
- Convert  sparse_coo_matrix to sparse_csr_matrix

The function for converting batched COO indices and values to CSR without creating sparse_coo_matrix, is motivated by the fact that sparse encoding is much easier in COO format, but COO only supports int64 for indices. Therefore this function will allow the creating of int32 encoded CSR tensors without the wasted overhead of int64 which has been leading to OOM errors in my work.

I have also experimented with using the module "parameterized" to improve the ease and readability of unit testing.
