### PR TITLE
Batched mm

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -40,4 +40,4 @@ jobs:
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Run unittests
       run: |
-        python -m unittest
+        python -m pytest

--- a/README.md
+++ b/README.md
@@ -30,5 +30,5 @@ or
 A number of unittests are provided, which can be run as:
 
 ```
-python -m unittest
+python -m pytest
 ```

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,3 +3,4 @@ numpy
 scipy
 jax[cpu]
 parameterized
+pytest

--- a/tests/test_sparse_matmul.py
+++ b/tests/test_sparse_matmul.py
@@ -1,109 +1,139 @@
 import torch
-import unittest
-from random import randrange
-from torchsparsegradutils import sparse_mm
+import pytest
+
+from torchsparsegradutils import sparse_mm#, sparse_bmm
+from torchsparsegradutils.utils import rand_sparse, rand_sparse_tri
+
+# Identify Testing Parameters
+DEVICES = [torch.device("cpu")]
+if torch.cuda.is_available():
+    DEVICES.append(torch.device("cuda"))
+
+TEST_DATA = [
+    # name  A_shape, B_shape, A_nnz
+    ("unbat", (4, 6), (6, 2), 8),            # unbatched       
+    ("unbat", (8, 16), (16, 10), 32),        # -
+    ("unbat", (7, 4), (4, 9), 14),           # -
+    
+    ("bat", (1, 4, 6), (1, 6, 2), 8),      # batched
+    ("bat", (4, 8, 16), (4, 16, 10), 32),  # -
+    ("bat", (11, 7, 4), (11, 4, 9), 14),   # -
+    
+]
+
+INDEX_DTYPES = [torch.int32, torch.int64]
+VALUE_DTYPES = [torch.float32, torch.float64]
+
+ATOL=1e-6  # relaxed tolerance to allow for float32
+RTOL=1e-4
+
+# Define Test Names:
+def data_id(shapes):
+    return shapes[0]
+
+def device_id(device):
+    return str(device)
+
+def dtype_id(dtype):
+    return str(dtype).split('.')[-1]
+
+# Define Fixtures
+
+@pytest.fixture(params=TEST_DATA, ids=[data_id(d) for d in TEST_DATA])
+def shapes(request):
+    return request.param
+
+@pytest.fixture(params=VALUE_DTYPES, ids=[dtype_id(d) for d in VALUE_DTYPES])
+def value_dtype(request):
+    return request.param
+
+@pytest.fixture(params=INDEX_DTYPES, ids=[dtype_id(d) for d in INDEX_DTYPES])
+def index_dtype(request):
+    return request.param
+
+@pytest.fixture(params=DEVICES, ids=[device_id(d) for d in DEVICES])
+def device(request):
+    return request.param
+
+# Define Tests
+
+def forward_routine(op_test, op_ref, layout, device, value_dtype, index_dtype, shapes):
+    if index_dtype == torch.int32 and layout is torch.sparse_coo:
+        pytest.skip("Skipping test as sparse COO tensors with int32 indices are not supported")
+        
+    _, A_shape, B_shape, A_nnz = shapes
+    A = rand_sparse(A_shape, A_nnz, layout, indices_dtype=index_dtype, values_dtype=value_dtype, device=device)
+    B = torch.rand(*B_shape, dtype=value_dtype, device=device)
+    Ad = A.to_dense()
+    
+    res_sparse = op_test(A, B)  # both results are dense
+    res_dense = op_ref(Ad, B)
+    
+    torch.allclose(res_sparse, res_dense, atol=ATOL, rtol=RTOL)
+
+def backward_routine(op_test, op_ref, layout, device, value_dtype, index_dtype, shapes, is_backward=False):
+    if index_dtype == torch.int32 and layout is torch.sparse_coo:
+        pytest.skip("Skipping test as sparse COO tensors with int32 indices are not supported")
+    
+    _, A_shape, B_shape, A_nnz = shapes
+    As1 = rand_sparse(A_shape, A_nnz, layout, indices_dtype=index_dtype, values_dtype=value_dtype, device=device)
+    Ad2 = As1.detach().clone().to_dense()  # detach and clone to create seperate graph
+    
+    Bd1 = torch.rand(*B_shape, dtype=value_dtype, device=device)
+    Bd2 = Bd1.detach().clone()
+    
+    As1.requires_grad_()
+    Ad2.requires_grad_()
+    Bd1.requires_grad_()
+    Bd2.requires_grad_()
+    
+    res1 = op_test(As1, Bd1)  # both results are dense
+    res2 = op_ref(Ad2, Bd2)
+    
+    # Generate random gradients for the backward pass
+    grad_output = torch.rand_like(res1, dtype=value_dtype, device=device)
+    
+    res1.backward(grad_output)
+    res2.backward(grad_output)
+    
+    nz_mask = As1.grad.to_dense() != 0.0
+    
+    assert torch.allclose(As1.grad.to_dense()[nz_mask], Ad2.grad[nz_mask], atol=ATOL, rtol=RTOL)
+    assert torch.allclose(Bd1.grad, Bd2.grad, atol=ATOL, rtol=RTOL)
 
 
-def gencoordinates(nr, nc, ni, device="cuda"):
-    """Used to genererate ni random unique coordinates for sparse matrix with size [nr, nc]"""
-    coordinates = set()
-    while True:
-        r, c = randrange(nr), randrange(nc)
-        coordinates.add((r, c))
-        if len(coordinates) == ni:
-            return torch.stack([torch.tensor(co) for co in coordinates], dim=-1).to(device)
+def test_sparse_mm_forward_result_coo(device, value_dtype, index_dtype, shapes):
+    forward_routine(sparse_mm, torch.matmul, torch.sparse_coo, device, value_dtype, index_dtype, shapes)
+
+def test_sparse_mm_forward_result_csr(device, value_dtype, index_dtype, shapes):
+    forward_routine(sparse_mm, torch.matmul, torch.sparse_csr, device, value_dtype, index_dtype, shapes)
+
+def test_sparse_mm_backward_result_coo(device, value_dtype, index_dtype, shapes):
+    backward_routine(sparse_mm, torch.matmul, torch.sparse_coo, device, value_dtype, index_dtype, shapes, is_backward=True)
+
+def test_sparse_mm_backward_result_csr(device, value_dtype, index_dtype, shapes):
+    backward_routine(sparse_mm, torch.matmul, torch.sparse_csr, device, value_dtype, index_dtype, shapes, is_backward=True)
 
 
-class SparseMatMulTest(unittest.TestCase):
-    """Test Sparse x Dense matrix multiplication with back propagation for COO and CSR matrices"""
+# Additional Testing Parameters
+BAD_TEST_DATA = [
+    # name, A, B, expected_error, error_msg
+    ("bad_tensor", 5, torch.rand(6, 2), ValueError, "Both A and B should be instances of torch.Tensor"), 
+    ("bad_dim_A", torch.tensor([0,1]).to_sparse(), torch.rand(6, 2), ValueError, "Both A and B should be at least 2-dimensional tensors"), 
+    ("bad_dim_B", torch.rand(4, 6).to_sparse(), torch.rand(6), ValueError, "Both A and B should be at least 2-dimensional tensors"),
+    ("bad_dim_mismatch", torch.rand(4, 6).to_sparse(), torch.rand(1, 6, 2), ValueError, "Both A and B should have the same number of dimensions"),
+    ("bad_format", torch.rand(4, 6).to_sparse_csc(), torch.rand(6, 2), ValueError, "A should be in either COO or CSR format"),
+    ("bad_batch", torch.stack([torch.rand(4, 6).to_sparse(), torch.rand(4, 6).to_sparse()]), torch.rand(1, 6, 2), ValueError, "If A and B have a leading batch dimension, they should have the same batch size"),
+]
 
-    def setUp(self) -> None:
-        # The device can be specialised by a daughter class
-        if not hasattr(self, "device"):
-            self.device = torch.device("cpu")
-        self.A_shape = (8, 16)
-        self.B_shape = (self.A_shape[1], 10)
-        self.A_nnz = 32
-        self.A_idx = gencoordinates(*self.A_shape, self.A_nnz, device=self.device)
-        self.A_val = torch.randn(self.A_nnz, dtype=torch.float64, device=self.device)
-        self.As_coo = torch.sparse_coo_tensor(self.A_idx, self.A_val, self.A_shape, requires_grad=True).coalesce()
-        self.As_csr = self.As_coo.to_sparse_csr()
-        self.Ad = self.As_coo.to_dense()
+# Additional Fixture
+@pytest.fixture(params=BAD_TEST_DATA, ids=[data_id(d) for d in BAD_TEST_DATA])
+def bad_inputs(request):
+    return request.param
 
-        self.Bd = torch.randn(*self.B_shape, dtype=torch.float64, requires_grad=True, device=self.device)
-        self.matmul = sparse_mm
-
-    def test_matmul_forward_coo(self):
-        x = self.matmul(self.As_coo, self.Bd)
-        self.assertIsInstance(x, torch.Tensor)
-
-    def test_matmul_forward_csr(self):
-        x = self.matmul(self.As_csr, self.Bd)
-        self.assertIsInstance(x, torch.Tensor)
-
-    def test_matmul_gradient_coo(self):
-        # Sparse matmul:
-        As1 = self.As_coo.detach().clone()
-        As1.requires_grad = True
-        Bd1 = self.Bd.detach().clone()
-        Bd1.requires_grad = True
-        As1.retain_grad()
-        Bd1.retain_grad()
-        x = self.matmul(As1, Bd1)
-        loss = x.sum()
-        loss.backward()
-
-        # torch dense matmul:
-        Ad2 = self.Ad.detach().clone()
-        Ad2.requires_grad = True
-        Bd2 = self.Bd.detach().clone()
-        Bd2.requires_grad = True
-        Ad2.retain_grad()
-        Bd2.retain_grad()
-        x_torch = Ad2 @ Bd2
-        loss_torch = x_torch.sum()
-        loss_torch.backward()
-
-        nz_mask = As1.grad.to_dense() != 0.0
-        self.assertTrue(torch.isclose(As1.grad.to_dense()[nz_mask], Ad2.grad[nz_mask]).all())
-        self.assertTrue(torch.isclose(Bd1.grad, Bd2.grad).all())
-
-    def test_matmul_gradient_csr(self):
-        # Sparse solver:
-        As1 = self.As_csr.detach().clone()
-        As1.requires_grad = True
-        Bd1 = self.Bd.detach().clone()
-        Bd1.requires_grad = True
-        As1.retain_grad()
-        Bd1.retain_grad()
-        x = self.matmul(As1, Bd1)
-        loss = x.sum()
-        loss.backward()
-
-        # torch dense solver:
-        Ad2 = self.Ad.detach().clone()
-        Ad2.requires_grad = True
-        Bd2 = self.Bd.detach().clone()
-        Bd2.requires_grad = True
-        Ad2.retain_grad()
-        Bd2.retain_grad()
-        x_torch = Ad2 @ Bd2
-        loss_torch = x_torch.sum()
-        loss_torch.backward()
-        nz_mask = As1.grad.to_dense() != 0.0
-        self.assertTrue(torch.isclose(As1.grad.to_dense()[nz_mask], Ad2.grad[nz_mask]).all())
-        self.assertTrue(torch.isclose(Bd1.grad, Bd2.grad).all())
-
-
-class SparseMatMulTestCUDA(SparseMatMulTest):
-    """Override superclass setUp to run on GPU"""
-
-    def setUp(self) -> None:
-        if not torch.cuda.is_available():
-            self.skipTest(f"Skipping {self.__class__.__name__} since CUDA is not available")
-        self.device = torch.device("cuda")
-        super().setUp()
-
-
-if __name__ == "__main__":
-    unittest.main()
+# Additional Test
+def test_sparse_mm_error(bad_inputs):
+    _, A, B, expected_error, error_msg = bad_inputs
+    with pytest.raises(expected_error) as e:
+        sparse_mm(A, B)
+    assert str(e.value) == error_msg

--- a/torchsparsegradutils/sparse_matmul.py
+++ b/torchsparsegradutils/sparse_matmul.py
@@ -1,7 +1,40 @@
 import torch
+from torchsparsegradutils.utils import sparse_block_diag, sparse_block_diag_split, stack_csr
 
 
 def sparse_mm(A, B):
+    """
+    Performs a matrix multiplication between a sparse matrix A and a dense matrix B,
+    preserving the sparsity of the gradient with respect to A, permitting sparse backpropagation.
+    
+    The sparse matrix A can be in either COO or CSR format, and is expected
+    to be 2-dimensional, with an optional leading batch dimension. The dense matrix B 
+    should also be 2-dimensional, with a matching optional leading batch dimension. 
+    The batch size must be the same for both A and B.
+    
+    Args:
+        A (torch.Tensor): The sparse matrix in COO or CSR format.
+        B (torch.Tensor): The dense matrix.
+        
+    Returns:
+        torch.Tensor: The result of the matrix multiplication.
+    """
+    
+    if not isinstance(A, torch.Tensor) or not isinstance(B, torch.Tensor):
+        raise ValueError("Both A and B should be instances of torch.Tensor")
+
+    if A.dim() < 2 or B.dim() < 2:
+        raise ValueError("Both A and B should be at least 2-dimensional tensors")
+        
+    if A.dim() != B.dim():
+        raise ValueError("Both A and B should have the same number of dimensions")
+    
+    if A.layout not in {torch.sparse_coo, torch.sparse_csr}:
+        raise ValueError("A should be in either COO or CSR format")
+        
+    if A.dim() == 3 and A.size(0) != B.size(0):
+        raise ValueError("If A and B have a leading batch dimension, they should have the same batch size")
+        
     return SparseMatMul.apply(A, B)
 
 
@@ -18,11 +51,26 @@ class SparseMatMul(torch.autograd.Function):
 
     @staticmethod
     def forward(ctx, A, B):
+        ctx.batch_size = B.size()[0] if B.dim() == 3 else None
+        ctx.A_shape = A.size()  # (b), n, m
+        ctx.B_shape = B.size()  # (b), m, p
+        
         grad_flag = A.requires_grad or B.requires_grad
+        
         A, B = A.detach(), B.detach()
+        
+        if ctx.batch_size is not None:
+            A = sparse_block_diag(*A)
+            B = torch.cat([*B])
+        
         x = torch.sparse.mm(A, B)
-        x.requires_grad = grad_flag
+        
         ctx.save_for_backward(A, B)
+        
+        if ctx.batch_size is not None:
+            x = x.view(ctx.batch_size, ctx.A_shape[-2], ctx.B_shape[-1])
+        
+        x.requires_grad = grad_flag
         return x
 
     @staticmethod
@@ -40,7 +88,7 @@ class SparseMatMul(torch.autograd.Function):
         # We start by getting the i and j indices:
 
         if A.layout == torch.sparse_coo:
-            A_row_idx, A_col_idx = A.indices()
+            A_row_idx, A_col_idx = A._indices()
         elif A.layout == torch.sparse_csr:
             A_col_idx = A.col_indices()
             A_crow_idx = A.crow_indices()
@@ -50,6 +98,9 @@ class SparseMatMul(torch.autograd.Function):
             )
         else:
             raise ValueError(f"Unsupported layout: {A.layout}")
+        
+        if ctx.batch_size is not None:
+            grad = torch.cat([*grad])
 
         grad_select = grad.index_select(0, A_row_idx)  # grad[i, :]
         B_select = B.index_select(0, A_col_idx)  # B[j, :]
@@ -60,10 +111,20 @@ class SparseMatMul(torch.autograd.Function):
 
         # Create a sparse matrix of the gradient with respect to the nnz of A
         if A.layout == torch.sparse_coo:
-            gradA = torch.sparse_coo_tensor(A.indices(), gradA, A.shape)
+            gradA = torch.sparse_coo_tensor(A._indices(), gradA, A.shape)
         elif A.layout == torch.sparse_csr:
             gradA = torch.sparse_csr_tensor(A_crow_idx, A_col_idx, gradA, A.shape)
 
         # Now compute the dense gradient with respect to B
         gradB = torch.sparse.mm(A.t(), grad)
+        
+        if ctx.batch_size is not None:
+            shapes = ctx.A_shape[0]*(ctx.A_shape[-2:],)
+            gradA = sparse_block_diag_split(gradA, *shapes)
+            if A.layout == torch.sparse_coo:
+                gradA = torch.stack([*gradA])
+            else:
+                gradA = stack_csr([*gradA])  # NOTE: torch.stack does not work for csr tensors
+                
+            gradB = gradB.view(ctx.B_shape)
         return gradA, gradB

--- a/torchsparsegradutils/utils/__init__.py
+++ b/torchsparsegradutils/utils/__init__.py
@@ -2,5 +2,7 @@ from .linear_cg import linear_cg, LinearCGSettings
 from .minres import minres, MINRESSettings
 from .bicgstab import bicgstab, BICGSTABSettings
 from .lsmr import lsmr
+from .utils import convert_coo_to_csr_indices_values, convert_coo_to_csr, sparse_block_diag, sparse_block_diag_split, stack_csr
+from .random_sparse import rand_sparse, rand_sparse_tri
 
-__all__ = ["linear_cg", "LinearCGSettings", "minres", "MINRESSettings", "bicgstab", "BICGSTABSettings", "lsmr"]
+__all__ = ["linear_cg", "LinearCGSettings", "minres", "MINRESSettings", "bicgstab", "BICGSTABSettings", "lsmr", "convert_coo_to_csr_indices_values", "convert_coo_to_csr", "sparse_block_diag", "rand_sparse", "rand_sparse_tri", "sparse_block_diag_split", "stack_csr"]

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -14,6 +14,24 @@ import random
 from torchsparsegradutils.utils.utils import convert_coo_to_csr_indices_values
 
 
+def rand_sparse(size, nnz, layout=torch.sparse_coo, *, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
+    if layout == torch.sparse_coo:
+        return generate_random_sparse_coo_matrix(size, nnz, indices_dtype=indices_dtype, values_dtype=values_dtype, device=device)
+    elif layout == torch.sparse_csr:
+        return generate_random_sparse_csr_matrix(size, nnz, indices_dtype=indices_dtype, values_dtype=values_dtype, device=device)
+    else:
+        raise ValueError("Unsupported layout type. It should be either torch.sparse_coo or torch.sparse_csr")
+
+
+def rand_sparse_tri(size, nnz, layout=torch.sparse_coo, *, upper=True, indices_dtype=torch.int64, values_dtype=torch.float32, device=torch.device("cpu")):
+    if layout == torch.sparse_coo:
+        return generate_random_sparse_strictly_triangular_coo_matrix(size, nnz, upper=upper, indices_dtype=indices_dtype, values_dtype=values_dtype, device=device)
+    elif layout == torch.sparse_csr:
+        return generate_random_sparse_strictly_triangular_csr_matrix(size, nnz, upper=upper, indices_dtype=indices_dtype, values_dtype=values_dtype, device=device)
+    else:
+        raise ValueError("Unsupported layout type. It should be either torch.sparse_coo or torch.sparse_csr")
+    
+
 def _gen_indices_2d_coo(nr, nc, nnz, *, dtype=torch.int64, device=torch.device("cpu")):
     """Generates nnz random unique coordinates in COO format.
 

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -1,5 +1,42 @@
 import torch
 
+def stack_csr(tensors, dim=0):
+    """
+    Stacks a list of CSR tensors along the batch dimension.
+    This function is analogous to torch.stack() but for CSR tensors.
+
+    Args:
+        tensors (list): List of CSR tensors to be stacked.
+        dim (int): The axis to stack the tensors along. Default is 0.
+
+    Returns:
+        torch.Tensor: Stacked CSR tensor.
+    """
+    if not isinstance(tensors, (list, tuple)):
+        raise TypeError("Expected a list of tensors, but got {}.".format(type(tensors)))
+    
+    if len(tensors) == 0:
+        raise ValueError("Cannot stack empty list of tensors.")
+
+    if not all([tensor.shape == tensors[0].shape for tensor in tensors]):
+        raise ValueError("All tensors must have the same shape.")
+
+    if not all([tensor.layout == torch.sparse_csr for tensor in tensors]):
+        raise ValueError("All tensors must be CSR.")
+
+    if not all([tensor.ndim == 2 for tensor in tensors]):
+        raise ValueError("All tensors must be 2D.")
+    
+    crow_indices = torch.stack([tensor.crow_indices() for tensor in tensors], dim=dim)
+    col_indices = torch.stack([tensor.col_indices() for tensor in tensors], dim=dim)
+    values = torch.stack([tensor.values() for tensor in tensors], dim=dim)
+
+    shape = list(tensors[0].shape)
+    shape.insert(dim, len(tensors))
+    shape = tuple(shape)
+
+    return torch.sparse_csr_tensor(crow_indices, col_indices, values, shape)
+
 
 def _sort_coo_indices(indices):
     """
@@ -143,3 +180,218 @@ def _demcompress_crow_indices(crow_indices, num_rows):
     )
 
     return row_indices
+
+
+# use @torch.jit.script ?
+def sparse_block_diag(*sparse_tensors):
+    """
+    Function to create a block diagonal sparse matrix from provided sparse tensors.
+    This function is designed to replicate torch.block_diag(), but for sparse tensors,
+    but only supports 2D sparse tensors 
+    (whereas torch.block_diag() supports dense tensors of 0, 1 or 2 dimensions).
+
+    Args:
+        *sparse_tensors (torch.Tensor): Variable length list of sparse tensors. All input tensors must either be all 
+                                        sparse_coo or all sparse_csr format. The input sparse tensors must have exactly 
+                                        two sparse dimensions and no dense dimensions.
+
+    Returns:
+        A block diagonal sparse tensor in the same format (either sparse_coo or sparse_csr) as the input tensors.
+
+    Raises:
+        TypeError: If the inputs are not provided as a list or tuple.
+        ValueError: If no tensors are provided or if the provided tensors are not all of the same sparse format.
+        ValueError: If all sparse tensors do not have two sparse dimensions and zero dense dimensions.
+    """
+
+    for i, sparse_tensor in enumerate(sparse_tensors):
+        if not isinstance(sparse_tensor, torch.Tensor):
+            raise TypeError(f"TypeError: expected Tensor as element {i} in argument 0, but got {type(sparse_tensor).__name__}")
+
+    if len(sparse_tensors) == 0:
+        raise ValueError("At least one sparse tensor must be provided.")
+    
+    if all(sparse_tensor.layout == torch.sparse_coo for sparse_tensor in sparse_tensors):
+        layout = torch.sparse_coo
+    elif all(sparse_tensor.layout == torch.sparse_csr for sparse_tensor in sparse_tensors):
+        layout = torch.sparse_csr
+    else:
+        raise ValueError("Sparse tensors must either be all sparse_coo or all sparse_csr.")
+    
+    if not all(sparse_tensor.sparse_dim() == 2 for sparse_tensor in sparse_tensors):
+        raise ValueError("All sparse tensors must have two sparse dimensions.")
+    
+    if not all(sparse_tensor.dense_dim() == 0 for sparse_tensor in sparse_tensors):
+        raise ValueError("All sparse tensors must have zero dense dimensions.")
+
+    if len(sparse_tensors) == 1:
+        return sparse_tensors[0]
+    
+    if layout == torch.sparse_coo:
+        
+        row_indices_list = []
+        col_indices_list = []
+        values_list = []
+
+        num_row = 0
+        num_col = 0
+        
+        for i, sparse_tensor in enumerate(sparse_tensors):            
+            
+            sparse_tensor = sparse_tensor.coalesce() if not sparse_tensor.is_coalesced() else sparse_tensor
+            
+            row_indices, col_indices = sparse_tensor.indices()
+            
+            # calculate block offsets
+            # not in-place addition to avoid modifying the original tensor indices
+            row_indices = row_indices + i * sparse_tensor.size()[-2]
+            col_indices = col_indices + i * sparse_tensor.size()[-1]
+
+            # accumulate indices and values:
+            row_indices_list.append(row_indices)
+            col_indices_list.append(col_indices)
+            values_list.append(sparse_tensor.values())
+
+            # accumulate tensor sizes:
+            num_row += sparse_tensor.size()[-2]
+            num_col += sparse_tensor.size()[-1]
+
+            
+        row_indices = torch.cat(row_indices_list)
+        col_indices = torch.cat(col_indices_list)
+        values = torch.cat(values_list)
+
+        return torch.sparse_coo_tensor(torch.stack([row_indices, col_indices]), values, torch.Size([num_row, num_col]))
+    
+    elif layout == torch.sparse_csr:
+        
+        crow_indices_list = []
+        col_indices_list = []
+        values_list = []
+
+        num_row = 0
+        num_col = 0
+        
+        for i, sparse_tensor in enumerate(sparse_tensors):
+            
+            crow_indices = sparse_tensor.crow_indices()
+            col_indices = sparse_tensor.col_indices()
+            
+            # Calculate block offsets
+            # not in-place addition to avoid modifying the original tensor indices
+            if i > 0:
+                crow_indices = crow_indices[1:]
+                crow_indices = crow_indices + crow_indices_list[-1][-1]
+            col_indices = col_indices + i * sparse_tensor.size()[-1]
+
+            # accumulate tensor sizes:
+            num_row += sparse_tensor.size()[-2]
+            num_col += sparse_tensor.size()[-1]
+
+            # Accumulate indices and values:
+            crow_indices_list.append(crow_indices)
+            col_indices_list.append(col_indices)
+            values_list.append(sparse_tensor.values())
+
+        crow_indices = torch.cat(crow_indices_list)
+        col_indices = torch.cat(col_indices_list)
+        values = torch.cat(values_list)
+
+        return torch.sparse_csr_tensor(crow_indices, col_indices, values, torch.Size([num_row, num_col]))
+    
+    
+def sparse_block_diag_split(sparse_block_diag_tensor, *shapes):
+    """
+    Function to split a block diagonal sparse matrix into original sparse tensors.
+    
+    NOTE: Sparse COO tensors are assumed to already by coalesced. 
+    This is because newly created or indexed sparse COO tensors default to is_coalesced=False,
+    and running coalesce() imposes an unnecessary performance penalty.
+
+    Args:
+        sparse_block_diag_tensor (torch.Tensor): The input block diagonal sparse tensor.
+        *shapes (sequence of tuple): The shapes of the original tensors. This is required to correctly split the tensor.
+
+    Returns:
+        A list of original sparse tensors.
+
+    Raises:
+        TypeError: If the input tensor is not a sparse tensor.
+    """
+
+    if sparse_block_diag_tensor.layout == torch.sparse_coo:
+        layout = torch.sparse_coo
+    elif sparse_block_diag_tensor.layout == torch.sparse_csr:
+        layout = torch.sparse_csr
+    else:
+        raise ValueError("Input tensor format not supported. Only sparse_coo and sparse_csr are supported.")
+    
+    if not all(len(shape) == 2 for shape in shapes):
+        raise ValueError("All shapes must be two-dimensional.")
+        
+    if layout == torch.sparse_coo:
+        tensors = []
+        start_row = 0
+        start_col = 0
+        current_val_offset = 0
+
+        sparse_block_diag_tensor = sparse_block_diag_tensor.coalesce() if not sparse_block_diag_tensor.is_coalesced() else sparse_block_diag_tensor
+        
+        row_indices, col_indices = sparse_block_diag_tensor.indices()
+        values = sparse_block_diag_tensor.values()
+
+        for shape in shapes:
+            rows, cols = shape[-2], shape[-1]
+
+            mask_row = (start_row <= row_indices) & (row_indices < start_row + rows)
+            mask_col = (start_col <= col_indices) & (col_indices < start_col + cols)
+            mask = mask_row & mask_col
+
+            indices_sub = torch.stack((row_indices[mask] - start_row, col_indices[mask] - start_col))
+            values_sub = values[mask]
+
+            tensor_sub = torch.sparse_coo_tensor(indices_sub, values_sub, (rows, cols))
+            tensors.append(tensor_sub)
+
+            start_row += rows
+            start_col += cols
+            current_val_offset += rows * cols
+
+        return tuple(tensors)
+
+    elif layout == torch.sparse_csr:
+        tensors = []
+        start_row = 0
+        current_col_offset = 0
+        current_val_offset = 0
+        
+        crow_indices = sparse_block_diag_tensor.crow_indices()
+        col_indices = sparse_block_diag_tensor.col_indices()
+        values = sparse_block_diag_tensor.values()
+
+        for shape in shapes:
+            rows, cols = shape[-2], shape[-1]
+
+            # Compute the number of values in the sub-block
+            values_count = crow_indices[start_row + shape[0]] - crow_indices[start_row]
+
+            # Find the starting and ending points in crow_indices
+            start_ptr = crow_indices[start_row]
+            end_ptr = crow_indices[start_row + shape[0]]
+
+            # Apply the pointers to get the sub-block indices and values
+            col_indices_sub = col_indices[current_val_offset:current_val_offset+values_count] - current_col_offset
+            values_sub = values[current_val_offset:current_val_offset+values_count]
+
+            # Create the sub-block crow_indices
+            crow_indices_sub = crow_indices[start_row:start_row + shape[0] + 1] - start_ptr
+
+            # Construct the sub-block as a CSR tensor
+            tensor_sub = torch.sparse_csr_tensor(crow_indices_sub, col_indices_sub, values_sub, (rows, cols))
+
+            tensors.append(tensor_sub)
+            start_row += shape[0]
+            current_col_offset += cols
+            current_val_offset += values_count
+
+        return tuple(tensors)


### PR DESCRIPTION
solves #34  Adds support for batched sparse matrix with batched dense matrix multiplication

This was achieved by creating a block sparse matrix from batched sparse COO or CSR matrices, via the function sparse_block_diag and then performing the inverse with sparse_block_diag_split.

A function for stacking CSR tensors was also implemented as PyTorch currently lacks this support.

I have switched to testing using the pytest framework, as this has significantly improved test writing and readability, see test_sparse_matmul.py . All tests written with the unittest framework should still run.