### PR TITLE
Batched triangular solve

### DIFF
--- a/tests/test_sparse_solve.py
+++ b/tests/test_sparse_solve.py
@@ -1,10 +1,155 @@
 import torch
+import pytest
 import unittest
 from random import randrange
 from sys import platform
 from torchsparsegradutils import sparse_triangular_solve, sparse_generic_solve
-from torchsparsegradutils.utils import linear_cg, minres
+from torchsparsegradutils.utils import linear_cg, minres, rand_sparse, rand_sparse_tri
 
+
+# Identify Testing Parameters
+DEVICES = [torch.device("cpu")]
+if torch.cuda.is_available():
+    DEVICES.append(torch.device("cuda"))
+
+# Pytest test currently just implemented for unit triangular solve
+TEST_DATA = [
+    # name  A_shape, B_shape, A_nnz
+    ("unbat", (4, 4), (4, 2), 6),
+    ("unbat", (12, 12), (12, 6), 32),
+    ("bat", (2, 4, 4), (2, 4, 2), 6),
+    ("bat", (4, 12, 12), (4, 12, 6), 32),
+]
+
+INDEX_DTYPES = [torch.int32, torch.int64]
+VALUE_DTYPES = [torch.float32, torch.float64]
+
+UPPER = [True, False]
+UNITRIANGULAR = [True,]  # just unit triangular solve for now
+
+ATOL = 1e-6  # relaxed tolerance to allow for float32
+RTOL = 1e-4
+
+
+# Define Test Names:
+def data_id(shapes):
+    return shapes[0]
+
+
+def device_id(device):
+    return str(device)
+
+
+def dtype_id(dtype):
+    return str(dtype).split(".")[-1]
+
+def upper_id(upper):
+    return "upp" if upper else "low"
+
+def unitriangular_id(unitriangular):
+    return "unit" if unitriangular else "nonunit"
+
+
+# Define Fixtures
+
+
+@pytest.fixture(params=TEST_DATA, ids=[data_id(d) for d in TEST_DATA])
+def shapes(request):
+    return request.param
+
+
+@pytest.fixture(params=VALUE_DTYPES, ids=[dtype_id(d) for d in VALUE_DTYPES])
+def value_dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=INDEX_DTYPES, ids=[dtype_id(d) for d in INDEX_DTYPES])
+def index_dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=DEVICES, ids=[device_id(d) for d in DEVICES])
+def device(request):
+    return request.param
+
+@pytest.fixture(params=UPPER, ids=[upper_id(d) for d in UPPER])
+def upper(request):
+    return request.param
+
+@pytest.fixture(params=UNITRIANGULAR, ids=[unitriangular_id(d) for d in UNITRIANGULAR])
+def unitriangular(request):
+    return request.param
+
+# Define Tests
+
+
+def forward_routine(op_test, op_ref, layout, device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    if index_dtype == torch.int32 and layout is torch.sparse_coo:
+        pytest.skip("Skipping test as sparse COO tensors with int32 indices are not supported")
+    if platform == "win32" and device == torch.device("cpu"):
+        pytest.skip("Skipping triangular solve CPU tests as solver not implemented for Windows OS")
+
+    _, A_shape, B_shape, A_nnz = shapes
+    A = rand_sparse_tri(A_shape, A_nnz, layout, upper=upper, strict=unitriangular, indices_dtype=index_dtype, values_dtype=value_dtype, device=device)
+    B = torch.rand(*B_shape, dtype=value_dtype, device=device)
+    Ad = A.to_dense()
+
+    res_test = op_test(A, B, upper=upper, unitriangular=unitriangular)
+    res_ref = op_ref(Ad, B, upper=upper, unitriangular=unitriangular)
+
+    torch.allclose(res_test, res_ref, atol=ATOL, rtol=RTOL)
+
+
+def backward_routine(op_test, op_ref, layout, device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    if index_dtype == torch.int32 and layout is torch.sparse_coo:
+        pytest.skip("Skipping test as sparse COO tensors with int32 indices are not supported")
+    if platform == "win32" and device == torch.device("cpu"):
+        pytest.skip("Skipping triangular solve CPU tests as solver not implemented for Windows OS")
+
+    _, A_shape, B_shape, A_nnz = shapes
+    As1 = rand_sparse_tri(A_shape, A_nnz, layout, upper=upper, strict=unitriangular, indices_dtype=index_dtype, values_dtype=value_dtype, device=device)
+    Ad2 = As1.detach().clone().to_dense()  # detach and clone to create seperate graph
+
+    Bd1 = torch.rand(*B_shape, dtype=value_dtype, device=device)
+    Bd2 = Bd1.detach().clone()
+
+    As1.requires_grad_()
+    Ad2.requires_grad_()
+    Bd1.requires_grad_()
+    Bd2.requires_grad_()
+
+    res_test = op_test(As1, Bd1, upper=upper, unitriangular=unitriangular)  # could pass these in as kwargs
+    res_ref = op_ref(Ad2, Bd2, upper=upper, unitriangular=unitriangular)
+
+    # Generate random gradients for the backward pass
+    grad_output = torch.rand_like(res_test, dtype=value_dtype, device=device)
+
+    res_test.backward(grad_output)
+    res_ref.backward(grad_output)
+
+    nz_mask = As1.grad.to_dense() != 0.0
+
+    assert torch.allclose(As1.grad.to_dense()[nz_mask], Ad2.grad[nz_mask], atol=ATOL, rtol=RTOL)
+    assert torch.allclose(Bd1.grad, Bd2.grad, atol=ATOL, rtol=RTOL)
+
+
+def test_forward_result_coo(device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    forward_routine(sparse_triangular_solve, torch.linalg.solve_triangular, torch.sparse_coo, device, value_dtype, index_dtype, shapes, upper, unitriangular)
+
+
+def test_forward_result_csr(device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    forward_routine(sparse_triangular_solve, torch.linalg.solve_triangular, torch.sparse_csr, device, value_dtype, index_dtype, shapes, upper, unitriangular)
+
+
+def test_backward_result_coo(device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    backward_routine(sparse_triangular_solve, torch.linalg.solve_triangular, torch.sparse_coo, device, value_dtype, index_dtype, shapes, upper, unitriangular)
+
+
+def test_backward_result_csr(device, value_dtype, index_dtype, shapes, upper, unitriangular):
+    backward_routine(sparse_triangular_solve, torch.linalg.solve_triangular, torch.sparse_csr, device, value_dtype, index_dtype, shapes, upper, unitriangular)
+
+
+##### Older test, need restructuring: #####
 
 def gencoordinates_square_tri(n, ni, upper=True, device="cuda"):
     """Used to genererate ni random unique off-diagonal coordinates

--- a/torchsparsegradutils/sparse_solve.py
+++ b/torchsparsegradutils/sparse_solve.py
@@ -3,6 +3,68 @@ from .utils import convert_coo_to_csr, sparse_block_diag, sparse_block_diag_spli
 
 
 def sparse_triangular_solve(A, B, upper=True, unitriangular=False):
+    """
+    Solves a system of equations given by AX = B, where A is a sparse triangular matrix,
+    and B is a dense right-hand side matrix.
+
+    This function accepts both batched and unbatched inputs, and can work with either upper
+    or lower triangular matrices.
+
+    A can be in either COO (Coordinate Format) or CSR (Compressed Sparse Row) format. However,
+    if it is in COO format, it will be converted to CSR format before solving as the
+    triangular solve operation doesn't work well with COO format.
+
+    This function supports backpropagation, and preserves the sparsity of the gradient during
+    the backpass.
+
+    Args:
+        A (torch.Tensor): The left-hand side sparse triangular matrix. Must be a 2-dimensional
+                          (matrix) or 3-dimensional (batch of matrices) tensor, and must be in
+                          either COO or CSR format.
+        B (torch.Tensor): The right-hand side dense matrix. Must be a 2-dimensional (matrix) or
+                          3-dimensional (batch of matrices) tensor.
+        upper (bool, optional): If True, A is assumed to be an upper triangular matrix. If False,
+                                A is assumed to be a lower triangular matrix. Default is True.
+        unitriangular (bool, optional): If True, the diagonal elements of A are assumed to be 1
+                                        and are not used in the solve operation. Default is False.
+
+    Returns:
+        torch.Tensor: The solution of the system of equations.
+
+    Raises:
+        ValueError: If A and B are not both torch.Tensor instances, or if they don't have the same
+                    number of dimensions, or if they are not at least 2-dimensional, or if A is not
+                    in COO or CSR format, or if A and B are batched but don't have the same batch size.
+
+    Note:
+        The gradient with respect to the sparse matrix A is computed only for its
+        non-zero values to save memory.
+
+        For the backpropagation, a workaround is implemented for a known issue with
+        torch.triangular_solve on the CPU for lower triangular matrices. This issue and the
+        subsequent workaround are relevant only for PyTorch versions lower than 2.0 (see PyTorch
+        issue #88890).
+
+    References:
+        https://github.com/pytorch/pytorch/issues/87358
+        https://github.com/pytorch/pytorch/issues/88890
+    """
+
+    if not isinstance(A, torch.Tensor) or not isinstance(B, torch.Tensor):
+        raise ValueError("Both A and B should be instances of torch.Tensor")
+
+    if A.dim() < 2 or B.dim() < 2:
+        raise ValueError("Both A and B should be at least 2-dimensional tensors")
+
+    if A.dim() != B.dim():
+        raise ValueError("Both A and B should have the same number of dimensions")
+
+    if A.layout not in {torch.sparse_coo, torch.sparse_csr}:
+        raise ValueError("A should be in either COO or CSR format")
+
+    if A.dim() == 3 and A.size(0) != B.size(0):
+        raise ValueError("If A and B have a leading batch dimension, they should have the same batch size")
+
     return SparseTriangularSolve.apply(A, B, upper, unitriangular)
 
 
@@ -30,9 +92,9 @@ class SparseTriangularSolve(torch.autograd.Function):
         ctx.csr = True
         ctx.upper = upper
         ctx.ut = unitriangular
-        
+
         grad_flag = A.requires_grad or B.requires_grad
-        
+
         if ctx.batch_size is not None:
             A = sparse_block_diag(*A)
             B = torch.cat([*B])
@@ -43,23 +105,26 @@ class SparseTriangularSolve(torch.autograd.Function):
 
         x = torch.triangular_solve(B.detach(), A.detach(), upper=upper, unitriangular=unitriangular).solution
 
-        if ctx.batch_size is not None:
-            x = x.view(ctx.batch_size, ctx.A_shape[-2], ctx.B_shape[-1])
-        
         x.requires_grad = grad_flag
         ctx.save_for_backward(A, x.detach())
+
+        if ctx.batch_size is not None:
+            x = x.view(ctx.batch_size, ctx.A_shape[-2], ctx.B_shape[-1])
+
         return x
 
     @staticmethod
     def backward(ctx, grad):
         if ctx.batch_size is not None:
             grad = torch.cat([*grad])
-            
+
         A, x = ctx.saved_tensors
 
         # Backprop rule: gradB = A^{-T} grad
         # Check if a workaround for https://github.com/pytorch/pytorch/issues/88890 is needed
-        workaround88890 = A.device == torch.device("cpu") and (not ctx.upper) and ctx.ut
+        workaround88890 = (
+            A.device == torch.device("cpu") and (not ctx.upper) and ctx.ut and (int(torch.__version__[0]) < 2)
+        )
         if not workaround88890:
             gradB = torch.triangular_solve(grad, A, upper=ctx.upper, transpose=True, unitriangular=ctx.ut).solution
         else:
@@ -106,16 +171,16 @@ class SparseTriangularSolve(torch.autograd.Function):
             gradA = torch.sparse_coo_tensor(torch.stack([A_row_idx, A_col_idx]), gradA, A.shape)
         else:
             gradA = torch.sparse_csr_tensor(A_crow_idx, A_col_idx, gradA, A.shape)
-            
+
         if ctx.batch_size is not None:
             shapes = ctx.A_shape[0] * (ctx.A_shape[-2:],)
             gradA = sparse_block_diag_split(gradA, *shapes)
-            if A.layout == torch.sparse_coo:
+            if not ctx.csr:
                 gradA = torch.stack([*gradA])
             else:
                 gradA = stack_csr([*gradA])
 
-                gradB = gradB.view(ctx.B_shape)
+            gradB = gradB.view(ctx.B_shape)
 
         return gradA, gradB, None, None
 

--- a/torchsparsegradutils/utils/random_sparse.py
+++ b/torchsparsegradutils/utils/random_sparse.py
@@ -7,6 +7,9 @@ NOTE: Sparse CSR The index tensors crow_indices and col_indices should have elem
       This is as a result of the default linking of pytorch being with MKL LP64, which uses 32 bit integer indexing
 NOTE: The batches of sparse CSR tensors are dependent: the number of specified elements in all batches must be the same.
       This somewhat  artificial constraint allows efficient storage of the indices of different CSR batches.
+
+TODO: This code needs reformatting into just rand_sparse and rand_sparse_tri
+TODO: Add support for non-strict triangular matrices
 """
 import warnings
 import torch
@@ -41,6 +44,7 @@ def rand_sparse_tri(
     layout=torch.sparse_coo,
     *,
     upper=True,
+    strict=False,
     indices_dtype=torch.int64,
     values_dtype=torch.float32,
     device=torch.device("cpu"),

--- a/torchsparsegradutils/utils/utils.py
+++ b/torchsparsegradutils/utils/utils.py
@@ -154,6 +154,8 @@ def convert_coo_to_csr(sparse_coo_tensor):
         torch.Tensor: CSR sparse tensor.
     """
     if sparse_coo_tensor.layout == torch.sparse_coo:
+        if sparse_coo_tensor.is_coalesced() is False:
+            sparse_coo_tensor = sparse_coo_tensor.coalesce()
         crow_indices, col_indices, values = convert_coo_to_csr_indices_values(
             sparse_coo_tensor.indices(), sparse_coo_tensor.size()[-2], sparse_coo_tensor.values()
         )


### PR DESCRIPTION
Following the same approach as with batched sparse matrix multiplication, a sparse block diagonal matrix is used to perform the calculation over the batch elements.

Unit tests updated with pytest framework.

The previous work around due to issue GH-88890 has now been resolved for pytorch 2.0 and this is reflected in the code.