### PR TITLE
Remove arg_constraints warning and allow .to(device)

### DIFF
--- a/torchsparsegradutils/distributions/sparse_multivariate_normal.py
+++ b/torchsparsegradutils/distributions/sparse_multivariate_normal.py
@@ -76,6 +76,7 @@ class SparseMultivariateNormal(Distribution):
             in either torch.sparse_coo or torch.sparse_csr layout
     """
 
+    arg_contraints = {}
     # TODO: add in constraints
     # arg_constraints = {'loc': constraints.real_vector,
     #                    'diag': constraints.independent(constraints.positive, 1),

--- a/torchsparsegradutils/tests/test_encoders.py
+++ b/torchsparsegradutils/tests/test_encoders.py
@@ -406,6 +406,25 @@ def test_PVE_dtype_device(batch_size, layout, indices_dtype, values_dtype, devic
         assert sparse_matrix.col_indices().device.type == device.type
 
 
+def test_PVE_to_device(layout, device):
+    encoder = PairwiseVoxelEncoder(
+        radius=1.0,
+        volume_shape=(5, 5, 5, 5),
+        layout=layout,
+        indices_dtype=torch.int64,
+        device=torch.device("cpu"),
+    )
+    encoder.to(device)
+
+    if layout == torch.sparse_coo:
+        assert encoder.indices.device.type == device.type
+
+    elif layout == torch.sparse_csr:
+        assert encoder.crow_indices.device.type == device.type
+        assert encoder.col_indices.device.type == device.type
+        assert encoder.csr_permutation.device.type == device.type
+
+
 # Test based on expected indices in pairwise_coo_indices.yaml
 @pytest.mark.parametrize(
     "radius, volume_shape, diag, upper, channel_relation, expected_indices",


### PR DESCRIPTION
This PR fixes the warning that was arising from the SparseMultivariateNormal class __init__: 

UserWarning: <class 'torchsparsegradutils.distributions.sparse_multivariate_normal.SparseMultivariateNormal'> does not define `arg_constraints`. Please set `arg_constraints = {}` or initialize the distribution with `validate_args=False` to turn off validation.

This PR also adjusts the PairwiseVoxelEncoder to inherit from `torch.nn.Module` and implements a `_apply` function to allow the indices creating during class initialisation to be sent to a particular device using the .to(device) method or .cpu() and .cuda(). The attribute `.device` has also been implemented as a property determined by those indices.