### PR TITLE
Automated package deployment to PYPI

### DIFF
--- a/.github/workflows/deployment-pypi.yml
+++ b/.github/workflows/deployment-pypi.yml
@@ -1,0 +1,26 @@
+name: deployment-pypi
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Build and publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload dist/*


### PR DESCRIPTION
The PR introduces auto deployment of the package to the pypi repo.

- The workflow is triggered by publication of new release.
-  Variables `secrets.PYPI_USERNAME` and `secrets.PYPI_PASSWORD` should be added as repo secrets to publish on behalf of owners.