### PR TITLE
fix: use packaging.version for PyTorch version comparison

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
 dependencies = [
     "torch>=2.5",
     "scipy",
+    "packaging",
 ]
 
 [project.optional-dependencies]

--- a/torchsparsegradutils/indexed_matmul.py
+++ b/torchsparsegradutils/indexed_matmul.py
@@ -1,4 +1,5 @@
 import torch
+from packaging.version import parse as parse_version
 
 try:
     import dgl.ops as dglops
@@ -73,7 +74,7 @@ def segment_mm(a: torch.Tensor, b: torch.Tensor, seglen_a: torch.Tensor) -> torc
         >>> segment_mm(a, b, seglen_a).shape
         torch.Size([18, 2])
     """
-    if torch.__version__ < (2, 4):
+    if parse_version(torch.__version__) < parse_version("2.4"):
         raise NotImplementedError("PyTorch version is too old for nested tensors")
 
     if dgl_installed:
@@ -177,7 +178,7 @@ def gather_mm(a: torch.Tensor, b: torch.Tensor, idx_b: torch.Tensor) -> torch.Te
         tensor([[1., 2.],
                 [6., 8.]])
     """
-    if torch.__version__ < (2, 4):
+    if parse_version(torch.__version__) < parse_version("2.4"):
         raise NotImplementedError("PyTorch version is too old for nested tensors")
 
     if dgl_installed:

--- a/torchsparsegradutils/tests/test_encoders.py
+++ b/torchsparsegradutils/tests/test_encoders.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import pytest
 import torch
 import yaml
+from packaging.version import parse as parse_version
 
 # Import from the new pairwise_encoder module (recommended)
 from torchsparsegradutils.encoders import PairwiseEncoder
@@ -23,7 +24,7 @@ from torchsparsegradutils.encoders.pairwise_encoder import (
 )
 from torchsparsegradutils.utils.utils import _sort_coo_indices
 
-if torch.__version__ >= (2,):
+if parse_version(torch.__version__) >= parse_version("2.0"):
     # https://pytorch.org/docs/stable/generated/torch.sparse.check_sparse_tensor_invariants.html
     torch.sparse.check_sparse_tensor_invariants.enable()
 

--- a/torchsparsegradutils/tests/test_indexed_matmul.py
+++ b/torchsparsegradutils/tests/test_indexed_matmul.py
@@ -1,11 +1,6 @@
 import pytest
 import torch
 
-if torch.__version__ < (2, 4):
-    pytest.skip(
-        "Skipping test based on nested tensors since an old version of pytorch is used", allow_module_level=True
-    )
-
 from torchsparsegradutils import gather_mm, segment_mm
 
 # Identify Testing Parameters
@@ -92,3 +87,33 @@ def test_gather_mm(device, value_dtype, index_dtype, shapes):
 
     for i in range(N):
         assert torch.allclose(ab[i, :].squeeze(), a[i, :].squeeze() @ b[idx_b[i], :, :].squeeze(), atol=ATOL, rtol=RTOL)
+
+
+def test_segment_mm_raises_on_old_pytorch():
+    """Test that segment_mm raises NotImplementedError on PyTorch < 2.4."""
+    from unittest.mock import patch
+
+    from torchsparsegradutils import indexed_matmul
+
+    a = torch.randn(10, 4)
+    b = torch.randn(2, 4, 3)
+    seglen_a = torch.tensor([5, 5])
+
+    with patch.object(torch, "__version__", "2.3.0"):
+        with pytest.raises(NotImplementedError, match="PyTorch version is too old"):
+            indexed_matmul.segment_mm(a, b, seglen_a)
+
+
+def test_gather_mm_raises_on_old_pytorch():
+    """Test that gather_mm raises NotImplementedError on PyTorch < 2.4."""
+    from unittest.mock import patch
+
+    from torchsparsegradutils import indexed_matmul
+
+    a = torch.randn(3, 4)
+    b = torch.randn(2, 4, 5)
+    idx_b = torch.tensor([0, 1, 0])
+
+    with patch.object(torch, "__version__", "2.3.0"):
+        with pytest.raises(NotImplementedError, match="PyTorch version is too old"):
+            indexed_matmul.gather_mm(a, b, idx_b)


### PR DESCRIPTION
Fix version comparison bug where `torch.__version__` (string) was compared to a tuple `(2, 4)`, which raises `TypeError` in Python 3.

Uses `packaging.version.parse()` for proper semantic version comparison.