### PR TITLE
Add sparse_bidir_logsumexp: simultaneous row- and column-wise log-sum-exp

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ A comprehensive collection of utility functions to work with PyTorch sparse tens
 - Operates directly on the nonzero values (no dense materialisation), with a numerically stable max-shift
 - Supports COO/CSR/CSC layouts (unbatched 2-D and batched 3-D) and an `include_zeros` flag for structural-zero semantics
 - Fills the gap of [PyTorch issue #31394](https://github.com/pytorch/pytorch/issues/31394) (no native `scatter_logsumexp`)
+- `sparse_bidir_logsumexp`: Row- and column-wise `log-sum-exp` simultaneously in a single traversal
+- Fuses the two `sparse_logsumexp(dim=0)` / `sparse_logsumexp(dim=1)` passes into one batched scatter, sharing the index extraction and autograd graph
+- Returns `tuple`, `padded`, or `nested` output layouts
 
 **Sparse Linear System Solvers**
 - `sparse_triangular_solve`: Sparse triangular solver with batch support

--- a/docs/source/api/core.rst
+++ b/docs/source/api/core.rst
@@ -32,6 +32,8 @@ Sparse Reductions
 
 .. autofunction:: sparse_logsumexp
 
+.. autofunction:: sparse_bidir_logsumexp
+
 Sparse Linear Solvers
 ----------------------
 

--- a/torchsparsegradutils/__init__.py
+++ b/torchsparsegradutils/__init__.py
@@ -1,5 +1,5 @@
 from .indexed_matmul import gather_mm, segment_mm
-from .sparse_logsumexp import sparse_logsumexp
+from .sparse_logsumexp import sparse_bidir_logsumexp, sparse_logsumexp
 from .sparse_lstsq import sparse_generic_lstsq
 from .sparse_matmul import sparse_mm
 from .sparse_solve import sparse_generic_solve, sparse_triangular_solve
@@ -12,4 +12,5 @@ __all__ = [
     "sparse_generic_solve",
     "sparse_generic_lstsq",
     "sparse_logsumexp",
+    "sparse_bidir_logsumexp",
 ]

--- a/torchsparsegradutils/benchmarks/benchmark_suite.py
+++ b/torchsparsegradutils/benchmarks/benchmark_suite.py
@@ -21,6 +21,8 @@ BENCHMARK_SCRIPTS = [
     "batched_sparse_mm_rand.py",
     "sparse_logsumexp_rand.py",
     "sparse_logsumexp_suitesparse.py",
+    "sparse_bidir_logsumexp_rand.py",
+    "sparse_bidir_logsumexp_suitesparse.py",
 ]
 
 

--- a/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_rand.py
+++ b/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_rand.py
@@ -79,15 +79,27 @@ def run_sparse_bidir_logsumexp_benchmark():
                     layout_name = "coo" if layout == torch.sparse_coo else "csr"
                     print(f"\n  📊 Configuration: idx_dtype={idx_dt}, val_dtype={val_dt}, layout={layout_name}")
 
+                    # COO indices are always int64 -> skip int32 rather than mislabel a duplicate.
+                    if layout == torch.sparse_coo and idx_dt != torch.int64:
+                        print(f"    ⏭  skipping {layout_name} + {idx_dt} (COO indices are always int64)")
+                        continue
+
+                    # Generate once per config, outside the try so generation errors surface here.
+                    A_sparse = rand_sparse(
+                        A_shape, nnz, layout, indices_dtype=idx_dt, values_dtype=val_dt, device=device
+                    )
+                    actual_idx_dt = (
+                        A_sparse.col_indices().dtype
+                        if layout == torch.sparse_csr
+                        else A_sparse.coalesce().indices().dtype
+                    )
+                    assert actual_idx_dt == idx_dt, f"index dtype mislabel: requested {idx_dt}, built {actual_idx_dt}"
+
                     print_results_table_header()
 
                     for alg_name, alg_fn in ALGORITHMS:
                         try:
                             print(f"    🧮 Testing {alg_name} ({layout_name})...")
-
-                            A_sparse = rand_sparse(
-                                A_shape, nnz, layout, indices_dtype=idx_dt, values_dtype=val_dt, device=device
-                            )
 
                             (
                                 t_fwd,

--- a/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_rand.py
+++ b/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_rand.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Sparse Bidirectional Log-Sum-Exp Benchmark - Random Matrices
+
+Benchmarks ``sparse_bidir_logsumexp`` (both row- and column-wise reductions in a
+single traversal) against the two-call baseline
+``(sparse_logsumexp(A, dim=0), sparse_logsumexp(A, dim=1))`` on randomly generated
+sparse matrices of various sizes, sparsity patterns, layouts and dtypes. Forward
+and backward time and peak memory are measured; the baseline is what the single-
+pass primitive exists to beat. Both algorithms are driven through a single tensor
+(``output_layout="padded"`` / ``torch.cat``) so ``measure_op``'s ``.sum().backward()``
+exercises both reductions.
+"""
+
+import os
+import sys
+
+# Add the parent directory to sys.path to allow importing torchsparsegradutils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import numpy as np
+import torch
+from benchmark_utils import (
+    measure_op,
+    print_benchmark_header,
+    print_result_row,
+    print_results_table_header,
+    save_benchmark_results,
+)
+from tqdm import tqdm
+
+from torchsparsegradutils import sparse_bidir_logsumexp, sparse_logsumexp
+from torchsparsegradutils.utils import rand_sparse
+
+REPEATS = 100
+WARMUP_RUNS = 10
+
+# Only run on CUDA
+device = torch.device("cuda")
+assert torch.cuda.is_available(), "This benchmark requires a CUDA GPU"
+
+# problem sizes: (label, N, M, nnz)
+SIZES = [
+    ("small", 2**10, 2**10, 2**12),
+    ("medium", 2**12, 2**12, 2**14),
+    ("large", 2**14, 2**14, 2**16),
+    ("xlarge", 2**16, 2**16, 2**18),
+    ("million", 2**20, 2**20, 2**22),
+]
+
+INDEX_DTYPES = [torch.int32, torch.int64]
+VALUE_DTYPES = [torch.float32, torch.float64]
+LAYOUTS = [torch.sparse_coo, torch.sparse_csr]
+
+# Both ops return a single tensor so measure_op's out.sum().backward() drives both
+# reductions. B is an unused placeholder for measure_op's binary signature.
+ALGORITHMS = [
+    ("sparse_bidir_logsumexp", lambda A, B: sparse_bidir_logsumexp(A, output_layout="padded")),
+    ("two_call_baseline", lambda A, B: torch.cat([sparse_logsumexp(A, dim=0), sparse_logsumexp(A, dim=1)])),
+]
+
+
+def run_sparse_bidir_logsumexp_benchmark():
+    """Run the sparse bidirectional log-sum-exp benchmark suite."""
+
+    print_benchmark_header("Sparse Bidirectional Log-Sum-Exp Benchmark - Random Matrices")
+
+    records = []
+
+    for size_label, N, M, nnz in tqdm(SIZES, desc="Problem sizes"):
+        print(f"\n🔍 Testing size: {size_label} (N={N}, M={M}, nnz={nnz})")
+
+        A_shape = (N, M)
+        B = torch.zeros(1, device=device)  # unused placeholder for measure_op's binary signature
+
+        for idx_dt in tqdm(INDEX_DTYPES, desc="Index dtypes", leave=False):
+            for val_dt in tqdm(VALUE_DTYPES, desc="Value dtypes", leave=False):
+                for layout in tqdm(LAYOUTS, desc="Layouts", leave=False):
+                    layout_name = "coo" if layout == torch.sparse_coo else "csr"
+                    print(f"\n  📊 Configuration: idx_dtype={idx_dt}, val_dtype={val_dt}, layout={layout_name}")
+
+                    print_results_table_header()
+
+                    for alg_name, alg_fn in ALGORITHMS:
+                        try:
+                            print(f"    🧮 Testing {alg_name} ({layout_name})...")
+
+                            A_sparse = rand_sparse(
+                                A_shape, nnz, layout, indices_dtype=idx_dt, values_dtype=val_dt, device=device
+                            )
+
+                            (
+                                t_fwd,
+                                std_fwd,
+                                mem_fwd,
+                                std_mem_fwd,
+                                t_bwd,
+                                std_bwd,
+                                mem_bwd,
+                                std_mem_bwd,
+                            ) = measure_op(
+                                alg_fn,
+                                A_sparse,
+                                B,
+                                repeats=REPEATS,
+                                device=device,
+                                desc=f"{alg_name} ({layout_name})",
+                                warmup_runs=WARMUP_RUNS,
+                                remove_outliers=True,
+                            )
+
+                            print_result_row(
+                                f"{alg_name} ({layout_name})",
+                                (N, M),
+                                t_fwd,
+                                std_fwd,
+                                mem_fwd,
+                                std_mem_fwd,
+                                t_bwd,
+                                std_bwd,
+                                mem_bwd,
+                                std_mem_bwd,
+                            )
+
+                            records.append(
+                                {
+                                    "size": size_label,
+                                    "layout": layout_name,
+                                    "algo": alg_name,
+                                    "index_dt": str(idx_dt).split(".")[-1],
+                                    "value_dt": str(val_dt).split(".")[-1],
+                                    "N": N,
+                                    "M": M,
+                                    "nnz": nnz,
+                                    "fwd_time_us": t_fwd,
+                                    "fwd_time_std_us": std_fwd,
+                                    "fwd_mem_MB": mem_fwd,
+                                    "fwd_mem_std_MB": std_mem_fwd,
+                                    "bwd_time_us": t_bwd,
+                                    "bwd_time_std_us": std_bwd,
+                                    "bwd_mem_MB": mem_bwd,
+                                    "bwd_mem_std_MB": std_mem_bwd,
+                                }
+                            )
+
+                        except Exception as e:
+                            print(f"    ❌ {alg_name} ({layout_name}) failed: {e}")
+
+                            records.append(
+                                {
+                                    "size": size_label,
+                                    "layout": layout_name,
+                                    "algo": alg_name,
+                                    "index_dt": str(idx_dt).split(".")[-1],
+                                    "value_dt": str(val_dt).split(".")[-1],
+                                    "N": N,
+                                    "M": M,
+                                    "nnz": nnz,
+                                    "fwd_time_us": np.nan,
+                                    "fwd_time_std_us": np.nan,
+                                    "fwd_mem_MB": np.nan,
+                                    "fwd_mem_std_MB": np.nan,
+                                    "bwd_time_us": np.nan,
+                                    "bwd_time_std_us": np.nan,
+                                    "bwd_mem_MB": np.nan,
+                                    "bwd_mem_std_MB": np.nan,
+                                    "error": str(e),
+                                }
+                            )
+
+    # Save results
+    if records:
+        save_benchmark_results(records, "sparse_bidir_logsumexp_rand")
+
+    print("\n✅ Sparse bidirectional log-sum-exp benchmark completed!")
+
+
+if __name__ == "__main__":
+    run_sparse_bidir_logsumexp_benchmark()

--- a/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_suitesparse.py
+++ b/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_suitesparse.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""
+Sparse Bidirectional Log-Sum-Exp Benchmark - SuiteSparse Collection
+
+Benchmarks ``sparse_bidir_logsumexp`` (both row- and column-wise reductions in a
+single traversal) against the two-call baseline
+``(sparse_logsumexp(A, dim=0), sparse_logsumexp(A, dim=1))`` on real matrices from
+the SuiteSparse Matrix Collection (Rothberg/cfd2 ~123k x 123k, Williams/webbase-1M
+~1M x 1M). Forward and backward time and peak memory are measured. Both algorithms
+are driven through a single tensor (``output_layout="padded"`` / ``torch.cat``) so
+``measure_op``'s ``.sum().backward()`` exercises both reductions.
+"""
+
+import os
+import sys
+
+# Add the parent directory to sys.path to allow importing torchsparsegradutils
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", ".."))
+
+import numpy as np
+import torch
+from benchmark_utils import (
+    load_mat_from_suitesparse_collection,
+    measure_op,
+    print_benchmark_header,
+    print_result_row,
+    print_results_table_header,
+    save_benchmark_results,
+)
+from tqdm import tqdm
+
+from torchsparsegradutils import sparse_bidir_logsumexp, sparse_logsumexp
+
+REPEATS = 100
+WARMUP_RUNS = 10
+
+# Only run on CUDA
+device = torch.device("cuda")
+assert torch.cuda.is_available(), "This benchmark requires a CUDA GPU"
+
+INDEX_DTYPES = [torch.int32, torch.int64]
+VALUE_DTYPES = [torch.float32, torch.float64]
+LAYOUTS = [torch.sparse_coo, torch.sparse_csr]
+
+# Both ops return a single tensor so measure_op's out.sum().backward() drives both
+# reductions. B is an unused placeholder for measure_op's binary signature.
+ALGORITHMS = [
+    ("sparse_bidir_logsumexp", lambda A, B: sparse_bidir_logsumexp(A, output_layout="padded")),
+    ("two_call_baseline", lambda A, B: torch.cat([sparse_logsumexp(A, dim=0), sparse_logsumexp(A, dim=1)])),
+]
+
+MATRICES = [
+    ("Rothberg", "cfd2"),  # 123k x 123k
+    ("Williams", "webbase-1M"),  # 1M x 1M
+]
+
+
+def run_sparse_bidir_logsumexp_suitesparse_benchmark():
+    """Run the sparse bidirectional log-sum-exp benchmark suite with SuiteSparse matrices."""
+
+    print_benchmark_header("Sparse Bidirectional Log-Sum-Exp Benchmark - SuiteSparse Collection")
+
+    records = []
+    B = torch.zeros(1, device=device)  # unused placeholder for measure_op's binary signature
+
+    for dirname, matname in tqdm(MATRICES, desc="Matrices"):
+        A_np_coo = load_mat_from_suitesparse_collection(dirname, matname)
+        matrix_name = f"{dirname}/{matname}"
+        N, M = A_np_coo.shape
+        nnz = A_np_coo.nnz
+        print(f"📊 Matrix: {matrix_name}, shape={A_np_coo.shape}, nnz={nnz}")
+
+        for idx_dt in tqdm(INDEX_DTYPES, desc="Index dtypes", leave=False):
+            for val_dt in tqdm(VALUE_DTYPES, desc="Value dtypes", leave=False):
+                for layout in tqdm(LAYOUTS, desc="Layouts", leave=False):
+                    layout_name = "coo" if layout == torch.sparse_coo else "csr"
+                    print(f"\n🔍 Testing configuration: idx_dtype={idx_dt}, val_dtype={val_dt}, layout={layout_name}")
+
+                    indices = torch.tensor([A_np_coo.row, A_np_coo.col], dtype=idx_dt, device=device)
+                    values = torch.tensor(A_np_coo.data, dtype=val_dt, device=device)
+                    A_sparse = torch.sparse_coo_tensor(
+                        indices, values, A_np_coo.shape, dtype=val_dt, device=device
+                    ).coalesce()
+                    if layout == torch.sparse_csr:
+                        A_sparse = A_sparse.to_sparse_csr()
+
+                    print_results_table_header()
+
+                    for alg_name, alg_fn in ALGORITHMS:
+                        try:
+                            print(f"  🧮 Testing {alg_name} ({layout_name})...")
+
+                            (
+                                t_fwd,
+                                std_fwd,
+                                mem_fwd,
+                                std_mem_fwd,
+                                t_bwd,
+                                std_bwd,
+                                mem_bwd,
+                                std_mem_bwd,
+                            ) = measure_op(
+                                alg_fn,
+                                A_sparse,
+                                B,
+                                repeats=REPEATS,
+                                device=device,
+                                desc=f"{alg_name} ({layout_name})",
+                                warmup_runs=WARMUP_RUNS,
+                                remove_outliers=True,
+                            )
+
+                            print_result_row(
+                                f"{alg_name} ({layout_name})",
+                                (N, M),
+                                t_fwd,
+                                std_fwd,
+                                mem_fwd,
+                                std_mem_fwd,
+                                t_bwd,
+                                std_bwd,
+                                mem_bwd,
+                                std_mem_bwd,
+                            )
+
+                            records.append(
+                                {
+                                    "matrix": matrix_name,
+                                    "N": N,
+                                    "M": M,
+                                    "nnz": nnz,
+                                    "index_dt": str(idx_dt).split(".")[-1],
+                                    "value_dt": str(val_dt).split(".")[-1],
+                                    "layout": layout_name,
+                                    "algo": alg_name,
+                                    "fwd_time_us": t_fwd,
+                                    "fwd_time_std_us": std_fwd,
+                                    "fwd_mem_MB": mem_fwd,
+                                    "fwd_mem_std_MB": std_mem_fwd,
+                                    "bwd_time_us": t_bwd,
+                                    "bwd_time_std_us": std_bwd,
+                                    "bwd_mem_MB": mem_bwd,
+                                    "bwd_mem_std_MB": std_mem_bwd,
+                                }
+                            )
+
+                        except Exception as e:
+                            print(f"  ❌ {alg_name} ({layout_name}) failed: {e}")
+
+                            records.append(
+                                {
+                                    "matrix": matrix_name,
+                                    "N": N,
+                                    "M": M,
+                                    "nnz": nnz,
+                                    "index_dt": str(idx_dt).split(".")[-1],
+                                    "value_dt": str(val_dt).split(".")[-1],
+                                    "layout": layout_name,
+                                    "algo": alg_name,
+                                    "fwd_time_us": np.nan,
+                                    "fwd_time_std_us": np.nan,
+                                    "fwd_mem_MB": np.nan,
+                                    "fwd_mem_std_MB": np.nan,
+                                    "bwd_time_us": np.nan,
+                                    "bwd_time_std_us": np.nan,
+                                    "bwd_mem_MB": np.nan,
+                                    "bwd_mem_std_MB": np.nan,
+                                    "error": str(e),
+                                }
+                            )
+
+    if records:
+        save_benchmark_results(records, "sparse_bidir_logsumexp_suitesparse")
+
+    print("\n✅ Sparse bidirectional log-sum-exp SuiteSparse benchmark completed!")
+
+
+if __name__ == "__main__":
+    run_sparse_bidir_logsumexp_suitesparse_benchmark()

--- a/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_suitesparse.py
+++ b/torchsparsegradutils/benchmarks/sparse_bidir_logsumexp_suitesparse.py
@@ -76,13 +76,25 @@ def run_sparse_bidir_logsumexp_suitesparse_benchmark():
                     layout_name = "coo" if layout == torch.sparse_coo else "csr"
                     print(f"\n🔍 Testing configuration: idx_dtype={idx_dt}, val_dtype={val_dt}, layout={layout_name}")
 
-                    indices = torch.tensor([A_np_coo.row, A_np_coo.col], dtype=idx_dt, device=device)
+                    # COO indices are always int64 -> skip int32 rather than mislabel a duplicate.
+                    if layout == torch.sparse_coo and idx_dt != torch.int64:
+                        print(f"  ⏭  skipping {layout_name} + {idx_dt} (COO indices are always int64)")
+                        continue
+
                     values = torch.tensor(A_np_coo.data, dtype=val_dt, device=device)
-                    A_sparse = torch.sparse_coo_tensor(
+                    indices = torch.tensor([A_np_coo.row, A_np_coo.col], dtype=torch.int64, device=device)
+                    A_coo = torch.sparse_coo_tensor(
                         indices, values, A_np_coo.shape, dtype=val_dt, device=device
                     ).coalesce()
                     if layout == torch.sparse_csr:
-                        A_sparse = A_sparse.to_sparse_csr()
+                        # to_sparse_csr() gives int64 -> rebuild with the requested dtype so the label is honest.
+                        csr = A_coo.to_sparse_csr()
+                        A_sparse = torch.sparse_csr_tensor(
+                            csr.crow_indices().to(idx_dt), csr.col_indices().to(idx_dt), csr.values(), csr.shape
+                        )
+                        assert A_sparse.col_indices().dtype == idx_dt
+                    else:
+                        A_sparse = A_coo
 
                     print_results_table_header()
 

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -181,7 +181,9 @@ def _bidir_2d(input: Tensor, include_zeros: bool):
 
     Returns ``(col_lse (ncols,), row_lse (nrows,), padded (2, G))`` where
     ``G = max(nrows, ncols)`` and the ``padded`` tail (beyond each axis' length) is
-    ``-inf`` (empty groups).
+    ``-inf`` (empty groups). ``padded`` is the scatter's native output buffer, and
+    ``col_lse`` / ``row_lse`` are basic-slice *views* into it — the three returns cost
+    one allocation between them, not three.
     """
     nrows, ncols = input.shape
     rows, cols, vals, row_nnz, col_nnz = _row_col_val(input, nrows, ncols)

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -341,15 +341,20 @@ def sparse_bidir_logsumexp(
 ) -> Union[Tensor, "tuple[Tensor, Tensor]"]:
     r"""Simultaneous row- and column-wise log-sum-exp of a sparse tensor.
 
-    Computes the column-wise reduction (over rows, ``dim=0``) *and* the row-wise
-    reduction (over columns, ``dim=1``) of a 2-D (or batched 3-D) sparse tensor in a
-    single traversal of the sparse structure. Equivalent to, but cheaper than::
+    Computes the column-wise reduction (over rows) *and* the row-wise reduction (over
+    columns) of a 2-D (or batched 3-D) sparse tensor in a single traversal of the sparse
+    structure. For a 2-D input this equals::
 
         (sparse_logsumexp(input, dim=0, ...), sparse_logsumexp(input, dim=1, ...))
 
+    For a batched 3-D input the per-slice reductions use ``dim=1`` (over rows) and
+    ``dim=2`` (over columns) instead — ``dim=0`` is the batch axis and cannot be reduced.
+
     Every nonzero contributes to both outputs, so a single extraction feeds one batched
     :func:`~torch.Tensor.scatter_reduce_` (via ``values.expand(2, nnz)``, a view) rather
-    than two separate passes. Numerically stable via the same max-shift trick as
+    than two separate passes; the shared extraction and single autograd graph make it
+    faster than two calls (at a modestly higher peak memory, since both reductions are
+    live at once). Numerically stable via the same max-shift trick as
     :func:`sparse_logsumexp`.
 
     Parameters
@@ -369,15 +374,18 @@ def sparse_bidir_logsumexp(
     output_layout : {"tuple", "padded", "nested"}, default ``"tuple"``
         How to return the two reductions:
 
-        - ``"tuple"``: ``(col_lse, row_lse)`` — the most pythonic. ``col_lse`` is the
-          ``dim=0`` reduction (one value per column), ``row_lse`` the ``dim=1``
-          reduction (one value per row). **Note the order: column result first.**
+        - ``"tuple"``: ``(col_lse, row_lse)``. ``col_lse`` is the reduction over rows
+          (2-D ``dim=0``; batched ``dim=1``), shape ``(cols,)`` / ``(batch, cols)``;
+          ``row_lse`` is the reduction over columns (2-D ``dim=1``; batched ``dim=2``),
+          shape ``(rows,)`` / ``(batch, rows)``. **Note the order: column result first.**
         - ``"padded"``: a single dense tensor of shape ``(2, G)`` (unbatched) or
           ``(batch, 2, G)`` (batched) with ``G = max(rows, cols)``. Row ``0`` is
           ``col_lse``, row ``1`` is ``row_lse``; each is padded to ``G`` with ``-inf``.
         - ``"nested"``: ``torch.nested.as_nested_tensor([col_lse, row_lse])`` — a single
           container preserving the two (possibly different) lengths. Requires
-          PyTorch >= 2.4.
+          PyTorch >= 2.4, and (as a prototype API) is meant to be consumed via
+          ``.unbind()``; whole-tensor ops such as ``.sum()`` / ``.shape`` are not
+          supported on it. Emits PyTorch's nested-tensor prototype ``UserWarning``.
 
     Returns
     -------

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -398,6 +398,12 @@ def sparse_bidir_logsumexp(
           with ``-inf``. The direction leads in both cases, so ``out[0]`` / ``out[1]``
           select the two reductions regardless of rank. This is the scatter's native
           output buffer, returned without a copy.
+
+          .. warning::
+             Experimental. The axis order, the ``G = max(rows, cols)`` group padding and
+             the ``-inf`` fill mirror the internal scatter buffer, and may change without
+             a deprecation cycle if that buffer does. Use ``"tuple"`` for a stable layout.
+
         - ``"nested"``: ``torch.nested.as_nested_tensor([col_lse, row_lse])`` — a single
           container preserving the two (possibly different) lengths. Requires
           PyTorch >= 2.4, and (as a prototype API) is meant to be consumed via

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -252,22 +252,26 @@ def sparse_logsumexp(
     r"""Sparse-aware log-sum-exp, mirroring :func:`torch.logsumexp`.
 
     Computes :math:`\log \sum \exp(x)` along ``dim`` directly on the explicit
-    (nonzero) values of a 2-D (or batched 3-D) sparse tensor, without materialising
+    (nonzero) values of an unbatched or batched sparse tensor, without materialising
     the dense equivalent. The reduction is numerically stable via the max-shift trick.
 
     Parameters
     ----------
     input : Tensor
         A sparse tensor with layout ``torch.sparse_coo``, ``torch.sparse_csr`` or
-        ``torch.sparse_csc``. Either an unbatched 2-D matrix, or a batched 3-D
-        ``(batch, rows, cols)`` tensor whose leading dimension is an independent
-        batch (each ``(rows, cols)`` slice is reduced on its own). Any other layout
-        or rank raises ``NotImplementedError``.
+        ``torch.sparse_csc``. Either an unbatched ``[r, c]`` matrix, or a batched
+        ``[b, r, c]`` tensor whose leading dimension is an independent batch (each
+        ``[r, c]`` slice is reduced on its own). Any other layout or rank raises
+        ``NotImplementedError``.
+
+        Batched CSR/CSC inputs are supported, but PyTorch requires every slice of a
+        batched compressed tensor to hold the same number of specified elements --
+        a ragged batch can only be expressed as COO.
     dim : int or sequence of int
-        Dimension(s) to reduce. For a 2-D input: ``dim=1`` reduces the columns (one
-        value per row), ``dim=0`` reduces the rows (one value per column), and
-        ``[0, 1]`` reduces to a scalar. For a batched 3-D input the batch axis
-        (``0``) cannot be reduced; ``dim`` must select from ``{1, 2}``.
+        Dimension(s) to reduce. For an unbatched input: ``dim=1`` reduces the columns
+        (one value per row), ``dim=0`` reduces the rows (one value per column), and
+        ``[0, 1]`` reduces to a scalar. For a batched input the batch axis (``0``)
+        cannot be reduced; ``dim`` must select from ``{1, 2}``.
     keepdim : bool, default ``False``
         If ``True``, the reduced dimension(s) are retained with size 1.
     include_zeros : bool, default ``True``
@@ -356,13 +360,14 @@ def sparse_bidir_logsumexp(
     r"""Simultaneous row- and column-wise log-sum-exp of a sparse tensor.
 
     Computes the column-wise reduction (over rows) *and* the row-wise reduction (over
-    columns) of a 2-D (or batched 3-D) sparse tensor in a single traversal of the sparse
-    structure. For a 2-D input this equals::
+    columns) of an unbatched or batched sparse tensor in a single traversal of the sparse
+    structure. For an unbatched ``[r, c]`` input this equals::
 
         (sparse_logsumexp(input, dim=0, ...), sparse_logsumexp(input, dim=1, ...))
 
-    For a batched 3-D input the per-slice reductions use ``dim=1`` (over rows) and
-    ``dim=2`` (over columns) instead — ``dim=0`` is the batch axis and cannot be reduced.
+    For a batched ``[b, r, c]`` input the per-slice reductions use ``dim=1`` (over rows)
+    and ``dim=2`` (over columns) instead — ``dim=0`` is the batch axis and cannot be
+    reduced.
 
     Every nonzero contributes to both outputs, so a single extraction feeds one batched
     :func:`~torch.Tensor.scatter_reduce_` (via ``values.expand(2, nnz)``, a view) rather
@@ -375,9 +380,13 @@ def sparse_bidir_logsumexp(
     ----------
     input : Tensor
         A sparse tensor (``torch.sparse_coo`` / ``sparse_csr`` / ``sparse_csc``), either
-        an unbatched 2-D ``(rows, cols)`` matrix or a batched 3-D ``(batch, rows, cols)``
-        tensor whose leading axis is an independent batch. Any other layout or rank
-        raises ``NotImplementedError``.
+        an unbatched ``[r, c]`` matrix or a batched ``[b, r, c]`` tensor whose leading
+        axis is an independent batch. Any other layout or rank raises
+        ``NotImplementedError``.
+
+        Batched CSR/CSC inputs are supported, but PyTorch requires every slice of a
+        batched compressed tensor to hold the same number of specified elements --
+        a ragged batch can only be expressed as COO.
     keepdim : bool, default ``False``
         If ``True``, the reduced dimension is retained with size 1 in each returned
         vector. Only supported with ``output_layout="tuple"`` (raises otherwise).
@@ -389,18 +398,18 @@ def sparse_bidir_logsumexp(
         How to return the two reductions:
 
         - ``"tuple"``: ``(col_lse, row_lse)``. ``col_lse`` is the reduction over rows
-          (2-D ``dim=0``; batched ``dim=1``), shape ``(cols,)`` / ``(batch, cols)``;
-          ``row_lse`` is the reduction over columns (2-D ``dim=1``; batched ``dim=2``),
-          shape ``(rows,)`` / ``(batch, rows)``. **Note the order: column result first.**
+          (unbatched ``dim=0``; batched ``dim=1``), shape ``(c,)`` / ``(b, c)``;
+          ``row_lse`` is the reduction over columns (unbatched ``dim=1``; batched
+          ``dim=2``), shape ``(r,)`` / ``(b, r)``. **Note the order: column result first.**
         - ``"padded"``: a single dense tensor of shape ``(2, G)`` (unbatched) or
-          ``(2, batch, G)`` (batched) with ``G = max(rows, cols)``. Index ``0`` along the
+          ``(2, b, G)`` (batched) with ``G = max(r, c)``. Index ``0`` along the
           leading axis is ``col_lse``, index ``1`` is ``row_lse``; each is padded to ``G``
           with ``-inf``. The direction leads in both cases, so ``out[0]`` / ``out[1]``
           select the two reductions regardless of rank. This is the scatter's native
           output buffer, returned without a copy.
 
           .. warning::
-             Experimental. The axis order, the ``G = max(rows, cols)`` group padding and
+             Experimental. The axis order, the ``G = max(r, c)`` group padding and
              the ``-inf`` fill mirror the internal scatter buffer, and may change without
              a deprecation cycle if that buffer does. Use ``"tuple"`` for a stable layout.
 
@@ -440,7 +449,7 @@ def sparse_bidir_logsumexp(
     >>> torch.equal(col_lse, sparse_logsumexp(x, dim=0)) and torch.equal(row_lse, sparse_logsumexp(x, dim=1))
     True
 
-    The ``"padded"`` layout stacks both into one ``(2, max(rows, cols))`` tensor:
+    The ``"padded"`` layout stacks both into one ``(2, max(r, c))`` tensor:
 
     >>> sparse_bidir_logsumexp(x, output_layout="padded")
     tensor([[2.2395, 1.5514, 3.0949],

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -20,35 +20,42 @@ def _scatter_logsumexp(
     ``Tensor.scatter_reduce_``), so a group's members need not be contiguous. Uses
     the standard max-shift trick so that :math:`\exp` never overflows.
 
+    Any leading batch dimensions are supported: ``values`` / ``scatter_index`` of
+    shape ``(*batch, nnz)`` are reduced independently along the last axis into an
+    output of shape ``(*batch, n_groups)``. With no batch dims (1-D inputs) this is
+    an ordinary scatter reduction.
+
     Parameters
     ----------
-    values : Tensor, shape ``(nnz,)``
+    values : Tensor, shape ``(*batch, nnz)``
         The explicit (nonzero) values to reduce.
-    scatter_index : Tensor, shape ``(nnz,)``
-        Output group index for each value.
+    scatter_index : Tensor, shape ``(*batch, nnz)``
+        Output group index for each value, within ``[0, n_groups)``.
     n_groups : int
-        Number of output groups.
-    n_zeros_per_group : Tensor or None, shape ``(n_groups,)``
+        Number of output groups (size of the reduced last axis).
+    n_zeros_per_group : Tensor or None, shape ``(*batch, n_groups)``
         Count of structural zeros contributing ``exp(0) = 1`` to each group, or
         ``None`` to ignore structural zeros entirely.
 
     Returns
     -------
-    Tensor, shape ``(n_groups,)``
+    Tensor, shape ``(*batch, n_groups)``
         Per-group log-sum-exp. Empty groups (no values and no zeros) are ``-inf``.
     """
     device, dtype = values.device, values.dtype
+    batch = values.shape[:-1]
 
     # Per-group max, detached — a stability shift the result is invariant to.
-    max_val = torch.full((n_groups,), float("-inf"), device=device, dtype=dtype)
-    max_val.scatter_reduce_(0, scatter_index, values, reduce="amax", include_self=True)
+    max_val = torch.full((*batch, n_groups), float("-inf"), device=device, dtype=dtype)
+    max_val.scatter_reduce_(-1, scatter_index, values, reduce="amax", include_self=True)
     if n_zeros_per_group is not None:
         max_val = torch.where(n_zeros_per_group > 0, max_val.clamp(min=0.0), max_val)
     shift = max_val.detach().clone()
     shift[~shift.isfinite()] = 0.0  # empty groups (-inf) and +inf values (avoid inf - inf)
 
-    sum_exp = torch.zeros(n_groups, device=device, dtype=dtype)
-    sum_exp.scatter_reduce_(0, scatter_index, (values - shift[scatter_index]).exp(), reduce="sum", include_self=True)
+    sum_exp = torch.zeros((*batch, n_groups), device=device, dtype=dtype)
+    shifted_exp = (values - torch.gather(shift, -1, scatter_index)).exp()
+    sum_exp.scatter_reduce_(-1, scatter_index, shifted_exp, reduce="sum", include_self=True)
 
     # Structural zeros each contribute exp(0 - shift) = exp(-shift).
     if n_zeros_per_group is not None:

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -33,7 +33,11 @@ def _scatter_logsumexp(
     scatter_index : Tensor, shape ``(*batch, nnz)``
         Output group index for each value, within ``[0, n_groups)``.
     n_groups : int
-        Number of output groups (size of the reduced last axis).
+        Number of output groups (size of the reduced last axis). A single value shared
+        by every batch slice, since the output is a rectangular ``(*batch, n_groups)``.
+        A caller whose slices need *different* numbers of groups passes the maximum over
+        the slices and pads: the surplus groups of the shorter slices receive no values
+        and no zeros, so they come back ``-inf`` and can be sliced off.
     n_zeros_per_group : Tensor or None, shape ``(*batch, n_groups)``
         Count of structural zeros contributing ``exp(0) = 1`` to each group, or
         ``None`` to ignore structural zeros entirely.

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -213,7 +213,15 @@ def _bidir_batched(input: Tensor, include_zeros: bool):
     directions share one output). Batched inputs go through COO (batched CSR/CSC
     require equal nnz per slice in PyTorch).
 
-    Returns ``(col_lse (b, ncols), row_lse (b, nrows), padded (b, 2, G))``.
+    Returns ``(col_lse (b, ncols), row_lse (b, nrows), padded (2, b, G))``. As in
+    :func:`_bidir_2d` the three share one allocation: ``padded`` is the scatter's native
+    buffer and the other two are views into it.
+
+    Note ``padded`` comes back in that native ``(direction, batch, group)`` order, not
+    the ``(batch, direction, group)`` order the public ``output_layout="padded"``
+    documents. Transposing it is a copy, so the caller does it only on the path that
+    actually asks for that layout, rather than every call paying for a buffer the tuple
+    and nested paths discard.
     """
     b, nrows, ncols = input.shape
     coo = input if (input.layout == torch.sparse_coo and input.is_coalesced()) else input.to_sparse_coo().coalesce()
@@ -235,9 +243,7 @@ def _bidir_batched(input: Tensor, include_zeros: bool):
         n_zeros = None
 
     padded = _scatter_logsumexp(batched_vals, batched_idx, b * G, n_zeros).reshape(2, b, G)
-    col_lse = padded[0, :, :ncols]  # (b, ncols)
-    row_lse = padded[1, :, :nrows]  # (b, nrows)
-    return col_lse, row_lse, padded.permute(1, 0, 2).contiguous()  # padded: (b, 2, G)
+    return padded[0, :, :ncols], padded[1, :, :nrows], padded  # (b, ncols), (b, nrows), (2, b, G)
 
 
 def sparse_logsumexp(
@@ -463,7 +469,9 @@ def sparse_bidir_logsumexp(
     col_lse, row_lse, padded = _bidir_batched(input, include_zeros) if batched else _bidir_2d(input, include_zeros)
 
     if output_layout == "padded":
-        return padded
+        # The batched scatter's native buffer is (2, b, G); the documented layout is
+        # (b, 2, G). That transpose is a copy, and this is the only path that needs it.
+        return padded.permute(1, 0, 2).contiguous() if batched else padded
 
     if output_layout == "nested":
         return torch.nested.as_nested_tensor([col_lse, row_lse])

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -218,13 +218,7 @@ def _bidir_batched(input: Tensor, include_zeros: bool):
 
     Returns ``(col_lse (b, ncols), row_lse (b, nrows), padded (2, b, G))``. As in
     :func:`_bidir_2d` the three share one allocation: ``padded`` is the scatter's native
-    buffer and the other two are views into it.
-
-    Note ``padded`` comes back in that native ``(direction, batch, group)`` order, not
-    the ``(batch, direction, group)`` order the public ``output_layout="padded"``
-    documents. Transposing it is a copy, so the caller does it only on the path that
-    actually asks for that layout, rather than every call paying for a buffer the tuple
-    and nested paths discard.
+    buffer and the other two are views into it, and the direction is axis 0 in both.
     """
     b, nrows, ncols = input.shape
     coo = input if (input.layout == torch.sparse_coo and input.is_coalesced()) else input.to_sparse_coo().coalesce()
@@ -399,8 +393,11 @@ def sparse_bidir_logsumexp(
           ``row_lse`` is the reduction over columns (2-D ``dim=1``; batched ``dim=2``),
           shape ``(rows,)`` / ``(batch, rows)``. **Note the order: column result first.**
         - ``"padded"``: a single dense tensor of shape ``(2, G)`` (unbatched) or
-          ``(batch, 2, G)`` (batched) with ``G = max(rows, cols)``. Row ``0`` is
-          ``col_lse``, row ``1`` is ``row_lse``; each is padded to ``G`` with ``-inf``.
+          ``(2, batch, G)`` (batched) with ``G = max(rows, cols)``. Index ``0`` along the
+          leading axis is ``col_lse``, index ``1`` is ``row_lse``; each is padded to ``G``
+          with ``-inf``. The direction leads in both cases, so ``out[0]`` / ``out[1]``
+          select the two reductions regardless of rank. This is the scatter's native
+          output buffer, returned without a copy.
         - ``"nested"``: ``torch.nested.as_nested_tensor([col_lse, row_lse])`` — a single
           container preserving the two (possibly different) lengths. Requires
           PyTorch >= 2.4, and (as a prototype API) is meant to be consumed via
@@ -472,9 +469,7 @@ def sparse_bidir_logsumexp(
     col_lse, row_lse, padded = _bidir_batched(input, include_zeros) if batched else _bidir_2d(input, include_zeros)
 
     if output_layout == "padded":
-        # The batched scatter's native buffer is (2, b, G); the documented layout is
-        # (b, 2, G). That transpose is a copy, and this is the only path that needs it.
-        return padded.permute(1, 0, 2).contiguous() if batched else padded
+        return padded
 
     if output_layout == "nested":
         return torch.nested.as_nested_tensor([col_lse, row_lse])

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -278,6 +278,8 @@ def sparse_logsumexp(
     NotImplementedError
         If ``input`` is not a supported sparse layout, is not 2-D or 3-D, or if a
         batched 3-D input's ``dim`` includes the batch axis.
+    ValueError
+        If ``input`` is a hybrid sparse tensor (has dense dimensions).
 
     Examples
     --------
@@ -309,6 +311,9 @@ def sparse_logsumexp(
     supported = {torch.sparse_coo, torch.sparse_csr, torch.sparse_csc}
     if input.layout not in supported:
         raise NotImplementedError(f"sparse_logsumexp does not support layout {input.layout}. Supported: {supported}.")
+
+    if input.dense_dim() != 0:
+        raise ValueError("sparse_logsumexp requires a sparse tensor with zero dense dimensions.")
 
     # Validate against the raw dims (before normalising), matching torch.logsumexp.
     dims_list = [dim] if isinstance(dim, int) else list(dim)
@@ -398,7 +403,8 @@ def sparse_bidir_logsumexp(
         If ``input`` is not a supported sparse layout / rank, or ``output_layout=
         "nested"`` on a PyTorch older than 2.4.
     ValueError
-        If ``output_layout`` is unknown, or ``keepdim=True`` with a non-tuple layout.
+        If ``output_layout`` is unknown, ``keepdim=True`` with a non-tuple layout, or
+        ``input`` is a hybrid sparse tensor (has dense dimensions).
 
     Examples
     --------
@@ -433,6 +439,9 @@ def sparse_bidir_logsumexp(
             f"sparse_bidir_logsumexp does not support layout {input.layout}. Supported: {supported}."
         )
 
+    if input.dense_dim() != 0:
+        raise ValueError("sparse_bidir_logsumexp requires a sparse tensor with zero dense dimensions.")
+
     if output_layout not in ("tuple", "padded", "nested"):
         raise ValueError(
             f"sparse_bidir_logsumexp: unknown output_layout {output_layout!r}. "
@@ -440,6 +449,9 @@ def sparse_bidir_logsumexp(
         )
     if keepdim and output_layout != "tuple":
         raise ValueError("sparse_bidir_logsumexp: keepdim is only supported with output_layout='tuple'.")
+    # Gate the nested prototype up front, before paying the forward cost.
+    if output_layout == "nested" and parse_version(torch.__version__) < parse_version("2.4"):
+        raise NotImplementedError("PyTorch version is too old for nested tensors")
 
     batched = input.ndim == 3
     col_lse, row_lse, padded = _bidir_batched(input, include_zeros) if batched else _bidir_2d(input, include_zeros)
@@ -448,8 +460,6 @@ def sparse_bidir_logsumexp(
         return padded
 
     if output_layout == "nested":
-        if parse_version(torch.__version__) < parse_version("2.4"):
-            raise NotImplementedError("PyTorch version is too old for nested tensors")
         return torch.nested.as_nested_tensor([col_lse, row_lse])
 
     if keepdim:

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -146,6 +146,7 @@ def _logsumexp_batched(input: Tensor, dims, keepdim: bool, include_zeros: bool) 
     at once. Batched inputs go through COO (batched CSR/CSC require equal nnz per
     slice in PyTorch).
     """
+    # Not _scatter_logsumexp's batch axis: padding the ragged slices rectangular measured 2.6x slower.
     b, nrows, ncols = input.shape
     coo = input if (input.layout == torch.sparse_coo and input.is_coalesced()) else input.to_sparse_coo().coalesce()
     bidx, rows, cols = coo.indices()

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -1,9 +1,10 @@
-from typing import Sequence, Union
+from typing import Literal, Sequence, Union
 
 import torch
+from packaging.version import parse as parse_version
 from torch import Tensor
 
-__all__ = ["sparse_logsumexp"]
+__all__ = ["sparse_logsumexp", "sparse_bidir_logsumexp"]
 
 
 def _scatter_logsumexp(
@@ -164,6 +165,75 @@ def _logsumexp_batched(input: Tensor, dims, keepdim: bool, include_zeros: bool) 
     return result.unsqueeze(keep_ax) if keepdim else result
 
 
+def _bidir_2d(input: Tensor, include_zeros: bool):
+    """Row- and column-wise log-sum-exp of a 2-D sparse tensor in one batched scatter.
+
+    Both reductions run over the *same* nonzero values, so instead of two passes we
+    stack the two directions into a single batched ``_scatter_logsumexp``:
+    ``batch 0`` scatters by column (reducing rows -> ``col_lse``) and ``batch 1``
+    scatters by row (reducing columns -> ``row_lse``). ``values.expand(2, nnz)`` is a
+    view (no copy); its backward correctly *sums* each nonzero's row and column
+    gradient contributions.
+
+    Returns ``(col_lse (ncols,), row_lse (nrows,), padded (2, G))`` where
+    ``G = max(nrows, ncols)`` and the ``padded`` tail (beyond each axis' length) is
+    ``-inf`` (empty groups).
+    """
+    nrows, ncols = input.shape
+    rows, cols, vals, row_nnz, col_nnz = _row_col_val(input, nrows, ncols)
+    G = max(nrows, ncols)
+
+    batched_vals = vals.expand(2, vals.numel())  # (2, nnz) view, no copy
+    batched_idx = torch.stack([cols, rows])  # batch 0 -> col_lse, batch 1 -> row_lse
+
+    if include_zeros:
+        col_nnz = col_nnz if col_nnz is not None else torch.bincount(cols, minlength=ncols)
+        row_nnz = row_nnz if row_nnz is not None else torch.bincount(rows, minlength=nrows)
+        n_zeros = torch.zeros(2, G, device=vals.device, dtype=vals.dtype)  # padded tail stays 0
+        n_zeros[0, :ncols] = nrows - col_nnz.to(vals.dtype)
+        n_zeros[1, :nrows] = ncols - row_nnz.to(vals.dtype)
+    else:
+        n_zeros = None
+
+    padded = _scatter_logsumexp(batched_vals, batched_idx, G, n_zeros)  # (2, G)
+    return padded[0, :ncols], padded[1, :nrows], padded
+
+
+def _bidir_batched(input: Tensor, include_zeros: bool):
+    """Per-slice row- and column-wise log-sum-exp of a batched 3-D sparse tensor.
+
+    Same single batched scatter as :func:`_bidir_2d`, with the batch index folded into
+    the group index (each slice padded to ``G = max(nrows, ncols)`` groups so both
+    directions share one output). Batched inputs go through COO (batched CSR/CSC
+    require equal nnz per slice in PyTorch).
+
+    Returns ``(col_lse (b, ncols), row_lse (b, nrows), padded (b, 2, G))``.
+    """
+    b, nrows, ncols = input.shape
+    coo = input if (input.layout == torch.sparse_coo and input.is_coalesced()) else input.to_sparse_coo().coalesce()
+    bidx, rows, cols = coo.indices()
+    vals = coo.values()
+    G = max(nrows, ncols)
+
+    batched_vals = vals.expand(2, vals.numel())  # (2, nnz) view, no copy
+    batched_idx = torch.stack([bidx * G + cols, bidx * G + rows])  # into b*G groups
+
+    if include_zeros:
+        col_nnz = torch.bincount(bidx * ncols + cols, minlength=b * ncols).reshape(b, ncols)
+        row_nnz = torch.bincount(bidx * nrows + rows, minlength=b * nrows).reshape(b, nrows)
+        n_zeros = torch.zeros(2, b, G, device=vals.device, dtype=vals.dtype)  # padded tail stays 0
+        n_zeros[0, :, :ncols] = nrows - col_nnz.to(vals.dtype)
+        n_zeros[1, :, :nrows] = ncols - row_nnz.to(vals.dtype)
+        n_zeros = n_zeros.reshape(2, b * G)
+    else:
+        n_zeros = None
+
+    padded = _scatter_logsumexp(batched_vals, batched_idx, b * G, n_zeros).reshape(2, b, G)
+    col_lse = padded[0, :, :ncols]  # (b, ncols)
+    row_lse = padded[1, :, :nrows]  # (b, nrows)
+    return col_lse, row_lse, padded.permute(1, 0, 2).contiguous()  # padded: (b, 2, G)
+
+
 def sparse_logsumexp(
     input: Tensor,
     dim: Union[int, Sequence[int]],
@@ -261,3 +331,121 @@ def sparse_logsumexp(
     if 0 in dims:
         raise NotImplementedError("Cannot reduce the batch dimension (0) of a batched 3-D sparse tensor.")
     return _logsumexp_batched(input, dims, keepdim, include_zeros)
+
+
+def sparse_bidir_logsumexp(
+    input: Tensor,
+    keepdim: bool = False,
+    include_zeros: bool = True,
+    output_layout: Literal["tuple", "padded", "nested"] = "tuple",
+) -> Union[Tensor, "tuple[Tensor, Tensor]"]:
+    r"""Simultaneous row- and column-wise log-sum-exp of a sparse tensor.
+
+    Computes the column-wise reduction (over rows, ``dim=0``) *and* the row-wise
+    reduction (over columns, ``dim=1``) of a 2-D (or batched 3-D) sparse tensor in a
+    single traversal of the sparse structure. Equivalent to, but cheaper than::
+
+        (sparse_logsumexp(input, dim=0, ...), sparse_logsumexp(input, dim=1, ...))
+
+    Every nonzero contributes to both outputs, so a single extraction feeds one batched
+    :func:`~torch.Tensor.scatter_reduce_` (via ``values.expand(2, nnz)``, a view) rather
+    than two separate passes. Numerically stable via the same max-shift trick as
+    :func:`sparse_logsumexp`.
+
+    Parameters
+    ----------
+    input : Tensor
+        A sparse tensor (``torch.sparse_coo`` / ``sparse_csr`` / ``sparse_csc``), either
+        an unbatched 2-D ``(rows, cols)`` matrix or a batched 3-D ``(batch, rows, cols)``
+        tensor whose leading axis is an independent batch. Any other layout or rank
+        raises ``NotImplementedError``.
+    keepdim : bool, default ``False``
+        If ``True``, the reduced dimension is retained with size 1 in each returned
+        vector. Only supported with ``output_layout="tuple"`` (raises otherwise).
+    include_zeros : bool, default ``True``
+        As in :func:`sparse_logsumexp`: if ``True``, structural zeros contribute
+        ``exp(0) = 1`` (matching :func:`torch.logsumexp` on the dense tensor); if
+        ``False``, only explicit values participate.
+    output_layout : {"tuple", "padded", "nested"}, default ``"tuple"``
+        How to return the two reductions:
+
+        - ``"tuple"``: ``(col_lse, row_lse)`` — the most pythonic. ``col_lse`` is the
+          ``dim=0`` reduction (one value per column), ``row_lse`` the ``dim=1``
+          reduction (one value per row). **Note the order: column result first.**
+        - ``"padded"``: a single dense tensor of shape ``(2, G)`` (unbatched) or
+          ``(batch, 2, G)`` (batched) with ``G = max(rows, cols)``. Row ``0`` is
+          ``col_lse``, row ``1`` is ``row_lse``; each is padded to ``G`` with ``-inf``.
+        - ``"nested"``: ``torch.nested.as_nested_tensor([col_lse, row_lse])`` — a single
+          container preserving the two (possibly different) lengths. Requires
+          PyTorch >= 2.4.
+
+    Returns
+    -------
+    tuple[Tensor, Tensor] or Tensor
+        Depending on ``output_layout`` (see above).
+
+    Raises
+    ------
+    NotImplementedError
+        If ``input`` is not a supported sparse layout / rank, or ``output_layout=
+        "nested"`` on a PyTorch older than 2.4.
+    ValueError
+        If ``output_layout`` is unknown, or ``keepdim=True`` with a non-tuple layout.
+
+    Examples
+    --------
+    >>> i = torch.tensor([[0, 1, 1], [1, 0, 2]])
+    >>> v = torch.tensor([1.0, 2.0, 3.0])
+    >>> x = torch.sparse_coo_tensor(i, v, (3, 3))
+    >>> col_lse, row_lse = sparse_bidir_logsumexp(x)
+    >>> col_lse  # dim=0 reduction (one value per column)
+    tensor([2.2395, 1.5514, 3.0949])
+    >>> row_lse  # dim=1 reduction (one value per row)
+    tensor([1.5514, 3.3490, 1.0986])
+
+    Agrees with two separate :func:`sparse_logsumexp` calls:
+
+    >>> torch.equal(col_lse, sparse_logsumexp(x, dim=0)) and torch.equal(row_lse, sparse_logsumexp(x, dim=1))
+    True
+
+    The ``"padded"`` layout stacks both into one ``(2, max(rows, cols))`` tensor:
+
+    >>> sparse_bidir_logsumexp(x, output_layout="padded")
+    tensor([[2.2395, 1.5514, 3.0949],
+            [1.5514, 3.3490, 1.0986]])
+    """
+    if input.ndim not in (2, 3):
+        raise NotImplementedError(
+            f"sparse_bidir_logsumexp supports 2-D or batched 3-D sparse tensors, got ndim={input.ndim}."
+        )
+
+    supported = {torch.sparse_coo, torch.sparse_csr, torch.sparse_csc}
+    if input.layout not in supported:
+        raise NotImplementedError(
+            f"sparse_bidir_logsumexp does not support layout {input.layout}. Supported: {supported}."
+        )
+
+    if output_layout not in ("tuple", "padded", "nested"):
+        raise ValueError(
+            f"sparse_bidir_logsumexp: unknown output_layout {output_layout!r}. "
+            "Expected one of 'tuple', 'padded', 'nested'."
+        )
+    if keepdim and output_layout != "tuple":
+        raise ValueError("sparse_bidir_logsumexp: keepdim is only supported with output_layout='tuple'.")
+
+    batched = input.ndim == 3
+    col_lse, row_lse, padded = _bidir_batched(input, include_zeros) if batched else _bidir_2d(input, include_zeros)
+
+    if output_layout == "padded":
+        return padded
+
+    if output_layout == "nested":
+        if parse_version(torch.__version__) < parse_version("2.4"):
+            raise NotImplementedError("PyTorch version is too old for nested tensors")
+        return torch.nested.as_nested_tensor([col_lse, row_lse])
+
+    if keepdim:
+        # col_lse reduced dim=0 (2-D) / dim=1 (batched); row_lse reduced dim=1 / dim=2.
+        col_ax, row_ax = (1, 2) if batched else (0, 1)
+        col_lse, row_lse = col_lse.unsqueeze(col_ax), row_lse.unsqueeze(row_ax)
+    return col_lse, row_lse

--- a/torchsparsegradutils/sparse_logsumexp.py
+++ b/torchsparsegradutils/sparse_logsumexp.py
@@ -146,7 +146,9 @@ def _logsumexp_batched(input: Tensor, dims, keepdim: bool, include_zeros: bool) 
     at once. Batched inputs go through COO (batched CSR/CSC require equal nnz per
     slice in PyTorch).
     """
-    # Not _scatter_logsumexp's batch axis: padding the ragged slices rectangular measured 2.6x slower.
+    # Not _scatter_logsumexp's batch axis: it needs a rectangular (*batch, nnz), but COO slices can
+    # have unequal nnz (unlike CSR/CSC, which PyTorch forces equal). Padding them rectangular
+    # measured 2.6x slower, and far worse under skew.
     b, nrows, ncols = input.shape
     coo = input if (input.layout == torch.sparse_coo and input.is_coalesced()) else input.to_sparse_coo().coalesce()
     bidx, rows, cols = coo.indices()

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -5,9 +5,11 @@ from test_config import DEVICES, INDEX_DTYPES, SPARSE_LAYOUTS, VALUE_DTYPES
 
 # Reuse the sibling module's helpers/fixtures so the two suites stay in lock-step.
 from test_sparse_logsumexp import (
+    FWD_LAYOUTS,
     _assert_close,
     _dense_reference,
     _make_batched_dense,
+    _make_batched_dense_equal_nnz,
     _make_dense,
     _to_layout,
     device_id,
@@ -23,6 +25,16 @@ _NESTED_OK = parse_version(torch.__version__) >= parse_version("2.4")
 
 @pytest.fixture(params=SPARSE_LAYOUTS, ids=[layout_id(x) for x in SPARSE_LAYOUTS])
 def layout(request):
+    return request.param
+
+
+@pytest.fixture(params=FWD_LAYOUTS, ids=[layout_id(x) for x in FWD_LAYOUTS])
+def fwd_layout(request):
+    return request.param
+
+
+@pytest.fixture(params=FWD_LAYOUTS, ids=[layout_id(x) for x in FWD_LAYOUTS])
+def batched_layout(request):
     return request.param
 
 
@@ -46,10 +58,10 @@ def include_zeros(request):
     return request.param
 
 
-def test_matches_two_call_and_dense(layout, device, value_dtype, index_dtype, include_zeros):
+def test_matches_two_call_and_dense(fwd_layout, device, value_dtype, index_dtype, include_zeros):
     """(col_lse, row_lse) equals two sparse_logsumexp calls and the dense reference."""
     dense = _make_dense(device, value_dtype, seed=0)  # 5x4: has an all-zero row and column
-    sp = _to_layout(dense, layout, index_dtype)
+    sp = _to_layout(dense, fwd_layout, index_dtype)
     col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
     _assert_close(col_lse, sparse_logsumexp(sp, dim=0, include_zeros=include_zeros), value_dtype)
     _assert_close(row_lse, sparse_logsumexp(sp, dim=1, include_zeros=include_zeros), value_dtype)
@@ -57,10 +69,10 @@ def test_matches_two_call_and_dense(layout, device, value_dtype, index_dtype, in
     _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), value_dtype)
 
 
-def test_output_layouts_agree(layout, device, include_zeros):
+def test_output_layouts_agree(fwd_layout, device, include_zeros):
     """padded and nested carry the same values as tuple; padded pads to -inf."""
     dense = _make_dense(device, torch.float64, seed=1)  # 5x4 -> G=5, col_lse padded by one
-    sp = _to_layout(dense, layout)
+    sp = _to_layout(dense, fwd_layout)
     nrows, ncols = dense.shape
     G = max(nrows, ncols)
     col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
@@ -78,11 +90,11 @@ def test_output_layouts_agree(layout, device, include_zeros):
         _assert_close(parts[1], row_lse, torch.float64)
 
 
-def test_wide_matrix_row_padding(layout, device):
+def test_wide_matrix_row_padding(fwd_layout, device):
     """ncols > nrows exercises the row-side -inf padding; the tall (5x4) fixtures only
     ever hit the column-side pad, so transpose to a wide (4x5) matrix."""
     dense = _make_dense(device, torch.float64, seed=1).t().contiguous()  # (4, 5), wide
-    sp = _to_layout(dense, layout)
+    sp = _to_layout(dense, fwd_layout)
     nrows, ncols = dense.shape  # 4, 5 -> G=5
     G = max(nrows, ncols)
     col_lse, row_lse = sparse_bidir_logsumexp(sp)
@@ -94,18 +106,9 @@ def test_wide_matrix_row_padding(layout, device):
     assert torch.isneginf(padded[1, nrows:]).all()  # row_lse tail padded with -inf
 
 
-def test_csc_layout(device):
-    """CSC reaches sparse_bidir_logsumexp's free-col_nnz path; backward is unsupported
-    for CSC in PyTorch, so this is forward-only (matching the sibling suite)."""
-    dense = _make_dense(device, torch.float64, seed=2)
-    col_lse, row_lse = sparse_bidir_logsumexp(dense.to_sparse_csc())
-    _assert_close(col_lse, _dense_reference(dense, 0, True), torch.float64)
-    _assert_close(row_lse, _dense_reference(dense, 1, True), torch.float64)
-
-
-def test_keepdim_shapes(layout, device):
+def test_keepdim_shapes(fwd_layout, device):
     dense = _make_dense(device, torch.float64, seed=2)  # (5, 4)
-    sp = _to_layout(dense, layout)
+    sp = _to_layout(dense, fwd_layout)
     col_lse, row_lse = sparse_bidir_logsumexp(sp, keepdim=True)
     assert col_lse.shape == (1, 4)  # dim=0 reduction kept
     assert row_lse.shape == (5, 1)  # dim=1 reduction kept
@@ -124,7 +127,7 @@ def test_unknown_output_layout_raises(device):
         sparse_bidir_logsumexp(sp, output_layout="bogus")
 
 
-def test_all_negative_values_stability_both_axes(layout, device, include_zeros):
+def test_all_negative_values_stability_both_axes(fwd_layout, device, include_zeros):
     """Very-negative values on both axes: structural zeros must enter the shift so
     neither axis overflows to +inf or produces nan (the #87 blocking case, verified
     for the column reduction too)."""
@@ -133,16 +136,16 @@ def test_all_negative_values_stability_both_axes(layout, device, include_zeros):
         device=device,
         dtype=torch.float64,
     )
-    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, layout), include_zeros=include_zeros)
+    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, fwd_layout), include_zeros=include_zeros)
     _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), torch.float64)
     _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), torch.float64)
     assert not torch.isnan(col_lse).any() and not torch.isnan(row_lse).any()
 
 
-def test_positive_inf_value_both_axes(layout, device, include_zeros):
+def test_positive_inf_value_both_axes(fwd_layout, device, include_zeros):
     """An explicit +inf must yield +inf on both axes, not nan from inf - inf."""
     dense = torch.tensor([[float("inf"), 0.0, 1.0], [-2.0, 3.0, 0.0]], device=device, dtype=torch.float64)
-    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, layout), include_zeros=include_zeros)
+    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, fwd_layout), include_zeros=include_zeros)
     _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), torch.float64)
     _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), torch.float64)
     assert not torch.isnan(col_lse).any() and not torch.isnan(row_lse).any()
@@ -187,6 +190,34 @@ def test_batched_output_layouts_agree(device, include_zeros):
         parts = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="nested").unbind()
         _assert_close(parts[0], col_lse, torch.float64)  # (b, ncols)
         _assert_close(parts[1], row_lse, torch.float64)  # (b, nrows)
+
+
+def test_batched_all_layouts_match_two_call(batched_layout, device, value_dtype, include_zeros):
+    """Batched COO, CSR and CSC agree with the two-call baseline. The compressed layouts
+    take a different route in (converted, since batched CSR/CSC expose no per-slice index
+    accessors), so COO coverage alone would not exercise them."""
+    dense = _make_batched_dense_equal_nnz(device, value_dtype, seed=4)
+    sp = _to_layout(dense, batched_layout)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+    _assert_close(col_lse, sparse_logsumexp(sp, dim=1, include_zeros=include_zeros), value_dtype)
+    _assert_close(row_lse, sparse_logsumexp(sp, dim=2, include_zeros=include_zeros), value_dtype)
+    _assert_close(col_lse, _dense_reference(dense, 1, include_zeros), value_dtype)
+    _assert_close(row_lse, _dense_reference(dense, 2, include_zeros), value_dtype)
+
+
+def test_batched_all_layouts_output_shapes(batched_layout, device):
+    """The (2, b, G) padded buffer and the tuple/keepdim shapes hold for every layout."""
+    dense = _make_batched_dense_equal_nnz(device, torch.float64, seed=5)
+    sp = _to_layout(dense, batched_layout)
+    b, nrows, ncols = dense.shape
+    G = max(nrows, ncols)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp)
+    assert col_lse.shape == (b, ncols) and row_lse.shape == (b, nrows)
+
+    padded = sparse_bidir_logsumexp(sp, output_layout="padded")
+    assert padded.shape == (2, b, G)
+    _assert_close(padded[0, :, :ncols], col_lse, torch.float64)
+    _assert_close(padded[1, :, :nrows], row_lse, torch.float64)
 
 
 def test_bidir_returns_share_one_allocation(device):

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -16,6 +16,7 @@ from test_sparse_logsumexp import (
 )
 
 from torchsparsegradutils import sparse_bidir_logsumexp, sparse_logsumexp
+from torchsparsegradutils.sparse_logsumexp import _bidir_2d, _bidir_batched
 
 _NESTED_OK = parse_version(torch.__version__) >= parse_version("2.4")
 
@@ -186,6 +187,25 @@ def test_batched_output_layouts_agree(device, include_zeros):
         parts = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="nested").unbind()
         _assert_close(parts[0], col_lse, torch.float64)  # (b, ncols)
         _assert_close(parts[1], row_lse, torch.float64)  # (b, nrows)
+
+
+def test_bidir_returns_share_one_allocation(device):
+    """Both _bidir_* helpers return the scatter's native buffer plus two views into it,
+    so a batched tuple/nested call never materialises the transposed (b, 2, G) copy —
+    that copy belongs to output_layout='padded' alone."""
+    same_storage = lambda a, b: a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
+
+    dense = _make_dense(device, torch.float64, seed=7)  # (5, 4)
+    nrows, ncols = dense.shape
+    col, row, padded = _bidir_2d(dense.to_sparse_coo(), True)
+    assert same_storage(col, padded) and same_storage(row, padded)
+    assert padded.shape == (2, max(nrows, ncols))
+
+    bdense = _make_batched_dense(device, torch.float64, seed=7)  # (3, 5, 4)
+    b, nrows, ncols = bdense.shape
+    col, row, padded = _bidir_batched(bdense.to_sparse_coo(), True)
+    assert same_storage(col, padded) and same_storage(row, padded)
+    assert padded.shape == (2, b, max(nrows, ncols))  # native (direction, batch, group) order
 
 
 def test_gradient_parity_with_two_call(layout, device):

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -163,7 +163,7 @@ def test_batched_output_shapes(device):
     G = max(nrows, ncols)
     col_lse, row_lse = sparse_bidir_logsumexp(sp)
     assert col_lse.shape == (b, ncols) and row_lse.shape == (b, nrows)
-    assert sparse_bidir_logsumexp(sp, output_layout="padded").shape == (b, 2, G)
+    assert sparse_bidir_logsumexp(sp, output_layout="padded").shape == (2, b, G)
     ck, rk = sparse_bidir_logsumexp(sp, keepdim=True)
     assert ck.shape == (b, 1, ncols) and rk.shape == (b, nrows, 1)
 
@@ -178,10 +178,10 @@ def test_batched_output_layouts_agree(device, include_zeros):
     col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
 
     padded = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="padded")
-    assert padded.shape == (b, 2, G)
-    _assert_close(padded[:, 0, :ncols], col_lse, torch.float64)
-    _assert_close(padded[:, 1, :nrows], row_lse, torch.float64)
-    assert torch.isneginf(padded[:, 0, ncols:]).all()  # col-side -inf pad
+    assert padded.shape == (2, b, G)
+    _assert_close(padded[0, :, :ncols], col_lse, torch.float64)
+    _assert_close(padded[1, :, :nrows], row_lse, torch.float64)
+    assert torch.isneginf(padded[0, :, ncols:]).all()  # col-side -inf pad
 
     if _NESTED_OK:
         parts = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="nested").unbind()
@@ -191,8 +191,8 @@ def test_batched_output_layouts_agree(device, include_zeros):
 
 def test_bidir_returns_share_one_allocation(device):
     """Both _bidir_* helpers return the scatter's native buffer plus two views into it,
-    so a batched tuple/nested call never materialises the transposed (b, 2, G) copy —
-    that copy belongs to output_layout='padded' alone."""
+    and every output_layout is served from that one allocation — no layout copies it.
+    The direction leads in both ranks, so no transpose is needed to reach 'padded'."""
     same_storage = lambda a, b: a.untyped_storage().data_ptr() == b.untyped_storage().data_ptr()
 
     dense = _make_dense(device, torch.float64, seed=7)  # (5, 4)

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -77,6 +77,31 @@ def test_output_layouts_agree(layout, device, include_zeros):
         _assert_close(parts[1], row_lse, torch.float64)
 
 
+def test_wide_matrix_row_padding(layout, device):
+    """ncols > nrows exercises the row-side -inf padding; the tall (5x4) fixtures only
+    ever hit the column-side pad, so transpose to a wide (4x5) matrix."""
+    dense = _make_dense(device, torch.float64, seed=1).t().contiguous()  # (4, 5), wide
+    sp = _to_layout(dense, layout)
+    nrows, ncols = dense.shape  # 4, 5 -> G=5
+    G = max(nrows, ncols)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp)
+    _assert_close(col_lse, _dense_reference(dense, 0, True), torch.float64)
+    _assert_close(row_lse, _dense_reference(dense, 1, True), torch.float64)
+    padded = sparse_bidir_logsumexp(sp, output_layout="padded")
+    assert padded.shape == (2, G)
+    _assert_close(padded[1, :nrows], row_lse, torch.float64)
+    assert torch.isneginf(padded[1, nrows:]).all()  # row_lse tail padded with -inf
+
+
+def test_csc_layout(device):
+    """CSC reaches sparse_bidir_logsumexp's free-col_nnz path; backward is unsupported
+    for CSC in PyTorch, so this is forward-only (matching the sibling suite)."""
+    dense = _make_dense(device, torch.float64, seed=2)
+    col_lse, row_lse = sparse_bidir_logsumexp(dense.to_sparse_csc())
+    _assert_close(col_lse, _dense_reference(dense, 0, True), torch.float64)
+    _assert_close(row_lse, _dense_reference(dense, 1, True), torch.float64)
+
+
 def test_keepdim_shapes(layout, device):
     dense = _make_dense(device, torch.float64, seed=2)  # (5, 4)
     sp = _to_layout(dense, layout)
@@ -140,6 +165,27 @@ def test_batched_output_shapes(device):
     assert sparse_bidir_logsumexp(sp, output_layout="padded").shape == (b, 2, G)
     ck, rk = sparse_bidir_logsumexp(sp, keepdim=True)
     assert ck.shape == (b, 1, ncols) and rk.shape == (b, nrows, 1)
+
+
+def test_batched_output_layouts_agree(device, include_zeros):
+    """Batched padded/nested carry the same values as tuple (not just the right shape),
+    so a col/row plane swap in the padded assembly cannot pass unnoticed."""
+    dense = _make_batched_dense(device, torch.float64, seed=5)  # (3, 5, 4)
+    sp = dense.to_sparse_coo()
+    b, nrows, ncols = dense.shape
+    G = max(nrows, ncols)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+
+    padded = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="padded")
+    assert padded.shape == (b, 2, G)
+    _assert_close(padded[:, 0, :ncols], col_lse, torch.float64)
+    _assert_close(padded[:, 1, :nrows], row_lse, torch.float64)
+    assert torch.isneginf(padded[:, 0, ncols:]).all()  # col-side -inf pad
+
+    if _NESTED_OK:
+        parts = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="nested").unbind()
+        _assert_close(parts[0], col_lse, torch.float64)  # (b, ncols)
+        _assert_close(parts[1], row_lse, torch.float64)  # (b, nrows)
 
 
 def test_gradient_parity_with_two_call(layout, device):

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -1,0 +1,171 @@
+import pytest
+import torch
+from packaging.version import parse as parse_version
+from test_config import DEVICES, INDEX_DTYPES, SPARSE_LAYOUTS, VALUE_DTYPES
+
+# Reuse the sibling module's helpers/fixtures so the two suites stay in lock-step.
+from test_sparse_logsumexp import (
+    _assert_close,
+    _dense_reference,
+    _make_batched_dense,
+    _make_dense,
+    _to_layout,
+    device_id,
+    dtype_id,
+    layout_id,
+)
+
+from torchsparsegradutils import sparse_bidir_logsumexp, sparse_logsumexp
+
+_NESTED_OK = parse_version(torch.__version__) >= parse_version("2.4")
+
+
+@pytest.fixture(params=SPARSE_LAYOUTS, ids=[layout_id(x) for x in SPARSE_LAYOUTS])
+def layout(request):
+    return request.param
+
+
+@pytest.fixture(params=DEVICES, ids=[device_id(d) for d in DEVICES])
+def device(request):
+    return request.param
+
+
+@pytest.fixture(params=VALUE_DTYPES, ids=[dtype_id(d) for d in VALUE_DTYPES])
+def value_dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=INDEX_DTYPES, ids=[dtype_id(d) for d in INDEX_DTYPES])
+def index_dtype(request):
+    return request.param
+
+
+@pytest.fixture(params=[True, False], ids=["incl_zeros", "excl_zeros"])
+def include_zeros(request):
+    return request.param
+
+
+def test_matches_two_call_and_dense(layout, device, value_dtype, index_dtype, include_zeros):
+    """(col_lse, row_lse) equals two sparse_logsumexp calls and the dense reference."""
+    dense = _make_dense(device, value_dtype, seed=0)  # 5x4: has an all-zero row and column
+    sp = _to_layout(dense, layout, index_dtype)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+    _assert_close(col_lse, sparse_logsumexp(sp, dim=0, include_zeros=include_zeros), value_dtype)
+    _assert_close(row_lse, sparse_logsumexp(sp, dim=1, include_zeros=include_zeros), value_dtype)
+    _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), value_dtype)
+    _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), value_dtype)
+
+
+def test_output_layouts_agree(layout, device, include_zeros):
+    """padded and nested carry the same values as tuple; padded pads to -inf."""
+    dense = _make_dense(device, torch.float64, seed=1)  # 5x4 -> G=5, col_lse padded by one
+    sp = _to_layout(dense, layout)
+    nrows, ncols = dense.shape
+    G = max(nrows, ncols)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+
+    padded = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="padded")
+    assert padded.shape == (2, G)
+    _assert_close(padded[0, :ncols], col_lse, torch.float64)
+    _assert_close(padded[1, :nrows], row_lse, torch.float64)
+    assert torch.isneginf(padded[0, ncols:]).all()  # col_lse tail padded with -inf
+
+    if _NESTED_OK:
+        nested = sparse_bidir_logsumexp(sp, include_zeros=include_zeros, output_layout="nested")
+        parts = nested.unbind()
+        _assert_close(parts[0], col_lse, torch.float64)
+        _assert_close(parts[1], row_lse, torch.float64)
+
+
+def test_keepdim_shapes(layout, device):
+    dense = _make_dense(device, torch.float64, seed=2)  # (5, 4)
+    sp = _to_layout(dense, layout)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, keepdim=True)
+    assert col_lse.shape == (1, 4)  # dim=0 reduction kept
+    assert row_lse.shape == (5, 1)  # dim=1 reduction kept
+
+
+def test_keepdim_rejected_for_non_tuple_layouts(device):
+    sp = _make_dense(device, torch.float64, seed=3).to_sparse_coo()
+    for output_layout in ("padded", "nested"):
+        with pytest.raises(ValueError):
+            sparse_bidir_logsumexp(sp, keepdim=True, output_layout=output_layout)
+
+
+def test_unknown_output_layout_raises(device):
+    sp = _make_dense(device, torch.float64, seed=3).to_sparse_coo()
+    with pytest.raises(ValueError):
+        sparse_bidir_logsumexp(sp, output_layout="bogus")
+
+
+def test_all_negative_values_stability_both_axes(layout, device, include_zeros):
+    """Very-negative values on both axes: structural zeros must enter the shift so
+    neither axis overflows to +inf or produces nan (the #87 blocking case, verified
+    for the column reduction too)."""
+    dense = torch.tensor(
+        [[-1000.0, -5.0, 0.0], [-3.0, -900.0, -2.0], [0.0, 0.0, 0.0]],
+        device=device,
+        dtype=torch.float64,
+    )
+    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, layout), include_zeros=include_zeros)
+    _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), torch.float64)
+    _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), torch.float64)
+    assert not torch.isnan(col_lse).any() and not torch.isnan(row_lse).any()
+
+
+def test_positive_inf_value_both_axes(layout, device, include_zeros):
+    """An explicit +inf must yield +inf on both axes, not nan from inf - inf."""
+    dense = torch.tensor([[float("inf"), 0.0, 1.0], [-2.0, 3.0, 0.0]], device=device, dtype=torch.float64)
+    col_lse, row_lse = sparse_bidir_logsumexp(_to_layout(dense, layout), include_zeros=include_zeros)
+    _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), torch.float64)
+    _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), torch.float64)
+    assert not torch.isnan(col_lse).any() and not torch.isnan(row_lse).any()
+
+
+def test_batched_matches_two_call(device, value_dtype, include_zeros):
+    dense = _make_batched_dense(device, value_dtype, seed=4)  # (3, 5, 4)
+    sp = dense.to_sparse_coo()
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+    _assert_close(col_lse, sparse_logsumexp(sp, dim=1, include_zeros=include_zeros), value_dtype)
+    _assert_close(row_lse, sparse_logsumexp(sp, dim=2, include_zeros=include_zeros), value_dtype)
+
+
+def test_batched_output_shapes(device):
+    dense = _make_batched_dense(device, torch.float64, seed=5)  # (3, 5, 4)
+    sp = dense.to_sparse_coo()
+    b, nrows, ncols = dense.shape
+    G = max(nrows, ncols)
+    col_lse, row_lse = sparse_bidir_logsumexp(sp)
+    assert col_lse.shape == (b, ncols) and row_lse.shape == (b, nrows)
+    assert sparse_bidir_logsumexp(sp, output_layout="padded").shape == (b, 2, G)
+    ck, rk = sparse_bidir_logsumexp(sp, keepdim=True)
+    assert ck.shape == (b, 1, ncols) and rk.shape == (b, nrows, 1)
+
+
+def test_gradient_parity_with_two_call(layout, device):
+    """The values.expand(2, nnz) backward must sum each nonzero's row + column
+    gradient — identical to summing the two separate reductions' gradients."""
+    dense = _make_dense(device, torch.float64, seed=6)
+
+    def _grad(bidir):
+        leaf = dense.clone().requires_grad_(True)
+        sp = _to_layout(leaf, layout) if layout != torch.sparse_coo else leaf.to_sparse_coo()
+        if bidir:
+            col_lse, row_lse = sparse_bidir_logsumexp(sp)
+            (col_lse.sum() + row_lse.sum()).backward()
+        else:
+            (sparse_logsumexp(sp, dim=0).sum() + sparse_logsumexp(sp, dim=1).sum()).backward()
+        return leaf.grad
+
+    _assert_close(_grad(bidir=True), _grad(bidir=False), torch.float64)
+
+
+def test_unsupported_rank_raises(device):
+    x = torch.randn(2, 3, 4, 5, device=device).to_sparse_coo()
+    with pytest.raises(NotImplementedError):
+        sparse_bidir_logsumexp(x)
+
+
+def test_dense_layout_raises(device):
+    with pytest.raises(NotImplementedError):
+        sparse_bidir_logsumexp(torch.randn(3, 3, device=device))

--- a/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py
@@ -113,13 +113,13 @@ def test_keepdim_shapes(layout, device):
 def test_keepdim_rejected_for_non_tuple_layouts(device):
     sp = _make_dense(device, torch.float64, seed=3).to_sparse_coo()
     for output_layout in ("padded", "nested"):
-        with pytest.raises(ValueError):
+        with pytest.raises(ValueError, match="keepdim is only supported"):
             sparse_bidir_logsumexp(sp, keepdim=True, output_layout=output_layout)
 
 
 def test_unknown_output_layout_raises(device):
     sp = _make_dense(device, torch.float64, seed=3).to_sparse_coo()
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError, match="unknown output_layout"):
         sparse_bidir_logsumexp(sp, output_layout="bogus")
 
 
@@ -204,6 +204,37 @@ def test_gradient_parity_with_two_call(layout, device):
         return leaf.grad
 
     _assert_close(_grad(bidir=True), _grad(bidir=False), torch.float64)
+
+
+def test_batched_gradient_parity_with_two_call(device):
+    """_bidir_batched is a distinct backward path; its gradient must still match the
+    sum of the two separate batched reductions' gradients."""
+    dense = _make_batched_dense(device, torch.float64, seed=6)  # (3, 5, 4)
+
+    def _grad(bidir):
+        leaf = dense.clone().requires_grad_(True)
+        sp = leaf.to_sparse_coo()
+        if bidir:
+            col_lse, row_lse = sparse_bidir_logsumexp(sp)
+            (col_lse.sum() + row_lse.sum()).backward()
+        else:
+            (sparse_logsumexp(sp, dim=1).sum() + sparse_logsumexp(sp, dim=2).sum()).backward()
+        return leaf.grad
+
+    _assert_close(_grad(bidir=True), _grad(bidir=False), torch.float64)
+
+
+def test_duplicate_coordinates_are_coalesced(device, include_zeros):
+    """An uncoalesced COO with repeated coordinates must sum the duplicates before
+    exp (guards against a refactor to _values()/_indices() that would double-count)."""
+    indices = torch.tensor([[0, 0, 1], [1, 1, 2]], device=device)  # (0,1) appears twice
+    values = torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64, device=device)
+    sp = torch.sparse_coo_tensor(indices, values, (2, 3), device=device)  # NOT coalesced
+    assert not sp.is_coalesced()
+    dense = sp.to_dense()  # (0,1) -> 3.0 after summing
+    col_lse, row_lse = sparse_bidir_logsumexp(sp, include_zeros=include_zeros)
+    _assert_close(col_lse, _dense_reference(dense, 0, include_zeros), torch.float64)
+    _assert_close(row_lse, _dense_reference(dense, 1, include_zeros), torch.float64)
 
 
 def test_unsupported_rank_raises(device):

--- a/torchsparsegradutils/tests/test_sparse_logsumexp.py
+++ b/torchsparsegradutils/tests/test_sparse_logsumexp.py
@@ -17,7 +17,12 @@ def device_id(device):
 
 
 def layout_id(layout):
-    return "coo" if layout == torch.sparse_coo else "csr"
+    return {torch.sparse_coo: "coo", torch.sparse_csr: "csr", torch.sparse_csc: "csc"}[layout]
+
+
+# SPARSE_LAYOUTS (coo, csr) is the repo-wide matrix, and is what the gradient tests can
+# use: PyTorch has no backward for CSC values. Forward-only tests take the wider set.
+FWD_LAYOUTS = [*SPARSE_LAYOUTS, torch.sparse_csc]
 
 
 def dim_id(dim):
@@ -61,6 +66,11 @@ def layout(request):
     return request.param
 
 
+@pytest.fixture(params=FWD_LAYOUTS, ids=[layout_id(x) for x in FWD_LAYOUTS])
+def fwd_layout(request):
+    return request.param
+
+
 @pytest.fixture(params=DEVICES, ids=[device_id(d) for d in DEVICES])
 def device(request):
     return request.param
@@ -96,30 +106,23 @@ def _make_dense(device, value_dtype, seed):
     return dense.to(device=device, dtype=value_dtype)
 
 
-def test_matches_dense_reference(layout, device, value_dtype, index_dtype, dim, include_zeros):
+def test_matches_dense_reference(fwd_layout, device, value_dtype, index_dtype, dim, include_zeros):
     dense = _make_dense(device, value_dtype, seed=0)
-    sp = _to_layout(dense, layout, index_dtype)
+    sp = _to_layout(dense, fwd_layout, index_dtype)
     out = sparse_logsumexp(sp, dim=dim, include_zeros=include_zeros)
     ref = _dense_reference(dense, dim, include_zeros)
     _assert_close(out, ref, value_dtype)
 
 
-def test_keepdim_shapes(layout, device):
+def test_keepdim_shapes(fwd_layout, device):
     dense = _make_dense(device, torch.float64, seed=1)
-    sp = _to_layout(dense, layout)
+    sp = _to_layout(dense, fwd_layout)
     assert sparse_logsumexp(sp, dim=1, keepdim=True).shape == (5, 1)
     assert sparse_logsumexp(sp, dim=0, keepdim=True).shape == (1, 4)
     assert sparse_logsumexp(sp, dim=[0, 1], keepdim=True).shape == (1, 1)
 
 
-def test_csc_layout(device):
-    """CSC is supported even though it is not in the standard test matrix."""
-    dense = _make_dense(device, torch.float64, seed=2)
-    out = sparse_logsumexp(dense.to_sparse_csc(), dim=1, include_zeros=True)
-    _assert_close(out, torch.logsumexp(dense, dim=1), torch.float64)
-
-
-def test_all_negative_values_stability(layout, device, dim, include_zeros):
+def test_all_negative_values_stability(fwd_layout, device, dim, include_zeros):
     """All-negative values: the stability shift must account for the structural
     zero (value 0) so include_zeros neither overflows to +inf (rows with a zero)
     nor produces 0 * inf -> nan (fully dense rows). Row 0 has a structural zero,
@@ -129,7 +132,7 @@ def test_all_negative_values_stability(layout, device, dim, include_zeros):
         device=device,
         dtype=torch.float64,
     )
-    out = sparse_logsumexp(_to_layout(dense, layout), dim=dim, include_zeros=include_zeros)
+    out = sparse_logsumexp(_to_layout(dense, fwd_layout), dim=dim, include_zeros=include_zeros)
     _assert_close(out, _dense_reference(dense, dim, include_zeros), torch.float64)
     assert not torch.isnan(out).any()
 
@@ -141,10 +144,10 @@ def test_all_negative_single_value(device):
     _assert_close(sparse_logsumexp(x, dim=1, include_zeros=True), torch.logsumexp(x.to_dense(), dim=1), torch.float32)
 
 
-def test_positive_inf_value(layout, device, dim, include_zeros):
+def test_positive_inf_value(fwd_layout, device, dim, include_zeros):
     """An explicit +inf must yield +inf, not nan from inf - inf in the shift."""
     dense = torch.tensor([[float("inf"), 0.0, 1.0], [-2.0, 3.0, 0.0]], device=device, dtype=torch.float64)
-    out = sparse_logsumexp(_to_layout(dense, layout), dim=dim, include_zeros=include_zeros)
+    out = sparse_logsumexp(_to_layout(dense, fwd_layout), dim=dim, include_zeros=include_zeros)
     _assert_close(out, _dense_reference(dense, dim, include_zeros), torch.float64)
     assert not torch.isnan(out).any()
 
@@ -156,6 +159,28 @@ def _make_batched_dense(device, value_dtype, seed):
     dense = dense.masked_fill(torch.rand(3, 5, 4, generator=g) < 0.5, 0.0)
     dense[1, 2] = 0.0  # empty row within the second slice
     return dense.to(device=device, dtype=value_dtype)
+
+
+def _make_batched_dense_equal_nnz(device, value_dtype, seed):
+    """A (3, 5, 4) batched tensor whose slices share one sparsity mask.
+
+    Batched CSR/CSC cannot represent unequal nnz per slice: PyTorch raises "Expect the
+    same number of specified elements per batch" at *construction*, so a ragged tensor
+    like _make_batched_dense's can only be tested as COO. One shared mask (with an
+    all-zero row, so empty segments are still exercised) is the widest input all three
+    layouts can express.
+    """
+    g = torch.Generator().manual_seed(seed)
+    dense = torch.randn(3, 5, 4, generator=g, dtype=torch.float64)
+    mask = torch.rand(5, 4, generator=g) < 0.5  # one mask, broadcast over the batch
+    dense = dense.masked_fill(mask, 0.0)
+    dense[:, 2] = 0.0  # same all-zero row in every slice, keeping nnz equal
+    return dense.to(device=device, dtype=value_dtype)
+
+
+@pytest.fixture(params=FWD_LAYOUTS, ids=[layout_id(x) for x in FWD_LAYOUTS])
+def batched_layout(request):
+    return request.param
 
 
 @pytest.fixture(params=[1, 2, [1, 2]], ids=["dim1", "dim2", "dim12"])
@@ -173,6 +198,38 @@ def test_batched_matches_dense(device, value_dtype, batched_dim, include_zeros):
 def test_batched_keepdim_shapes(device):
     dense = _make_batched_dense(device, torch.float64, seed=5)
     sp = dense.to_sparse_coo()
+    assert sparse_logsumexp(sp, dim=1, keepdim=True).shape == (3, 1, 4)
+    assert sparse_logsumexp(sp, dim=2, keepdim=True).shape == (3, 5, 1)
+    assert sparse_logsumexp(sp, dim=[1, 2], keepdim=True).shape == (3, 1, 1)
+
+
+def test_batched_matches_dense_all_layouts(batched_layout, device, value_dtype, batched_dim, include_zeros):
+    """Batched COO, CSR and CSC all reduce per slice. The compressed layouts reach the
+    reduction by a different route than COO (they are converted, since batched CSR/CSC
+    have no per-slice index accessors), so they need covering, not just COO."""
+    dense = _make_batched_dense_equal_nnz(device, value_dtype, seed=4)
+    sp = _to_layout(dense, batched_layout)
+    out = sparse_logsumexp(sp, dim=batched_dim, include_zeros=include_zeros)
+    _assert_close(out, _dense_reference(dense, batched_dim, include_zeros), value_dtype)
+
+
+def test_batched_compressed_nnz_is_per_slice(device):
+    """Pins the convention behind the batched code path: _nnz() counts the *whole*
+    tensor for COO but a *single slice* for batched CSR/CSC. Any batched code that
+    reads _nnz() (or values().numel()) as a total is wrong for the compressed layouts
+    -- which is why the batched reduction converts to COO before counting."""
+    dense = _make_batched_dense_equal_nnz(device, torch.float64, seed=4)
+    b = dense.shape[0]
+    total_nnz = int((dense != 0).sum())
+
+    assert dense.to_sparse_coo().coalesce()._nnz() == total_nnz
+    for compressed in (torch.sparse_csr, torch.sparse_csc):
+        assert _to_layout(dense, compressed)._nnz() == total_nnz // b
+
+
+def test_batched_keepdim_shapes_all_layouts(batched_layout, device):
+    dense = _make_batched_dense_equal_nnz(device, torch.float64, seed=5)
+    sp = _to_layout(dense, batched_layout)
     assert sparse_logsumexp(sp, dim=1, keepdim=True).shape == (3, 1, 4)
     assert sparse_logsumexp(sp, dim=2, keepdim=True).shape == (3, 5, 1)
     assert sparse_logsumexp(sp, dim=[1, 2], keepdim=True).shape == (3, 1, 1)


### PR DESCRIPTION
## Summary

Adds `sparse_bidir_logsumexp` — computes the **column-wise (`dim=0`) and row-wise (`dim=1`) log-sum-exp of an unbatched `[r, c]` (or batched `[b, r, c]`) sparse tensor in a single traversal**, instead of two separate `sparse_logsumexp` passes. Every nonzero contributes to both outputs, so one extraction feeds a single batched scatter reduction.

Closes #88. Follow-up to `sparse_logsumexp` (#87 / #83).

Equivalent to, but cheaper than:

```python
(sparse_logsumexp(A, dim=0, ...), sparse_logsumexp(A, dim=1, ...))
```

## API

```python
sparse_bidir_logsumexp(
    input: Tensor,                 # sparse COO / CSR / CSC, unbatched [r, c] or batched [b, r, c]
    keepdim: bool = False,
    include_zeros: bool = True,
    output_layout: Literal["tuple", "padded", "nested"] = "tuple",
) -> tuple[Tensor, Tensor] | Tensor
```

- **`output_layout`** — how the two reductions come back:
  - `"tuple"` (default): `(col_lse, row_lse)`. **Column result first** — `col_lse` is the `dim=0` reduction (one value per column), `row_lse` the `dim=1` reduction (one value per row).
  - `"padded"`: one dense `(2, G)` tensor (unbatched) or `(2, b, G)` (batched), `G = max(r, c)`; index 0 along the leading axis = `col_lse`, index 1 = `row_lse`, each padded to `G` with `-inf`. The direction leads at both ranks, so `out[0]`/`out[1]` select the two reductions regardless of shape. This is the native output buffer — produced with no extra work.
  - `"nested"`: `torch.nested.as_nested_tensor([col_lse, row_lse])`, preserving the two lengths. Requires PyTorch ≥ 2.4.
- **`include_zeros`** — same semantics as `sparse_logsumexp`: `True` (default) treats structural zeros as `exp(0)=1` (matches dense `torch.logsumexp`), `False` treats them as `-inf`.
- **`keepdim`** — retains the reduced dim with size 1; only valid with `output_layout="tuple"` (raises otherwise).

```python
>>> x = torch.sparse_coo_tensor([[0, 1, 1], [1, 0, 2]], [1.0, 2.0, 3.0], (3, 3))
>>> col_lse, row_lse = sparse_bidir_logsumexp(x)
>>> col_lse                                    # == sparse_logsumexp(x, dim=0)
tensor([2.2395, 1.5514, 3.0949])
>>> row_lse                                    # == sparse_logsumexp(x, dim=1)
tensor([1.5514, 3.3490, 1.0986])
```

## Implementation notes

- **Single batched scatter.** Both directions run over the same nonzeros, so instead of two passes we stack them: `batched_vals = values.expand(2, nnz)` (a **view** — no value copy) and `batched_idx = torch.stack([cols, rows])`, then one call to the reduction. Batch 0 scatters by column (→ `col_lse`), batch 1 by row (→ `row_lse`). The `(2, G)` output *is* the `"padded"` layout; `tuple`/`nested` are slices of it.
- **`_scatter_logsumexp` generalised to a leading batch dim** (operates on the last axis; `n_zeros_per_group` gains a batch dim). The 1-D path is unchanged (`dim=-1 == 0`, `gather(…,-1,idx) == idx`-fancy-index), so `sparse_logsumexp`'s existing callers and their numerical fixes are untouched — guarded by the existing suite (198 tests still green).
- **Gradients match the two-call baseline.** `values.expand(2, nnz)`'s backward sums over the expanded dim, so each nonzero receives `∂(col_lse)/∂v + ∂(row_lse)/∂v`. Verified equal to the two-call baseline's gradients in the tests.
- **No dense / structural-zero materialisation.** Only `bincount` (per-axis nnz) and the `expand` view; the `(2, G)` buffers scale with `max(rows, cols)`, not nnz×2 or rows×cols. Numerical stability (very-negative-values-with-zeros, explicit `+inf`, empty rows/cols) is inherited from `_scatter_logsumexp` and re-tested here on **both** axes.
- **Same one-scatter path for batched `[b, r, c]` inputs**, with the batch index folded into the group index (each slice padded to `G` groups). Batched inputs go through COO (batched CSR/CSC require equal nnz per slice in PyTorch), matching `sparse_logsumexp`.

## Tests

`torchsparsegradutils/tests/test_sparse_bidir_logsumexp.py`, reusing the `sparse_logsumexp` fixtures/helpers so the two suites stay in lock-step. Parametrised over COO/CSR/CSC × value/index dtypes × `include_zeros`:

- `tuple` equals the two-call baseline **and** dense `torch.logsumexp`;
- `padded`/`nested` agree with `tuple`; `padded` pads to `-inf`;
- `keepdim` shapes, and its rejection for non-tuple layouts; unknown `output_layout` raises;
- the #87 numerical edge cases (very-negative values, explicit `+inf`) on **both** axes;
- batched shapes (`(b, c)` / `(b, r)` / `(2, b, G)` / keepdim);
- gradient parity with the two-call baseline;
- error paths (unsupported rank / dense layout).

282 tests pass (both suites + doctests); `black` / `isort` / `flake8` clean.

## Performance

Benchmarks added mirroring the `sparse_logsumexp` ones, comparing `sparse_bidir_logsumexp` against the two-call baseline `(sparse_logsumexp(A, dim=0), sparse_logsumexp(A, dim=1))`, forward+backward via `measure_op` (100 runs, IQR outlier removal), registered in `benchmark_suite`:

- `benchmarks/sparse_bidir_logsumexp_rand.py` — random CSR/COO up to 1M×1M (4.2M nnz), int32/int64 × float32/float64.
- `benchmarks/sparse_bidir_logsumexp_suitesparse.py` — real matrices `Rothberg/cfd2` (123k²) and `Williams/webbase-1M` (1M²), per the #87 review's ask for ≥1M-dim real matrices.

Quick random-CSR run (`float32`, forward and forward+backward, 50 runs with IQR outlier removal):

| N=M | nnz | bidir fwd / fwd+bwd | two-call fwd / fwd+bwd | fwd+bwd speedup | peak MB (bidir / two-call) |
|---|--:|--:|--:|--:|--:|
| 1,024 | 4,096 | 0.46 / 0.88 ms | 0.69 / 1.28 ms | 1.46× | 0.4 / 0.3 |
| 4,096 | 16,384 | 0.47 / 0.85 ms | 0.71 / 1.30 ms | 1.52× | 1.6 / 1.2 |
| 16,384 | 65,536 | 0.60 / 0.94 ms | 0.88 / 1.80 ms | 1.92× | 6.3 / 4.9 |
| 65,536 | 262,144 | 1.08 / 1.31 ms | 1.28 / 3.45 ms | 2.64× | 25.0 / 19.7 |
| 262,144 | 1,048,576 | 3.71 / 4.33 ms | 3.87 / 11.41 ms | 2.63× | 100 / 82 |

One extraction + one batched scatter beats two of each: **1.5×–2.6× faster on forward+backward, the margin growing with size** (the backward is where the shared single graph pays off most). Peak memory is ~20% higher than the sequential two-call path, since both reductions and their autograd graph are live at once rather than one-then-the-other.

<sub>Quick-run environment: NVIDIA RTX A1000 Laptop GPU (4 GB) · CPU dev box. Larger sizes (1M×1M) and the SuiteSparse matrices should be captured on the same box as #87 for the final numbers.</sub>
