### PR TITLE
Fix README rand_sparse_tri QuickStart example (#92) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ loc = torch.zeros(batch_size, event_size)
 
 scale_tril = rand_sparse_tri(
     (batch_size, event_size, event_size),
-    nnz=5000,  # 5000 non-zeros for 1000x1000 dense matrix (0.5% sparsity)
+    nnz=5000,  # 5000 non-zeros for 1000x1000 dense matrix (99.5% sparsity)
     layout=torch.sparse_csr,
     upper=False,
     strict=True  # Strict triangular (exclude diagonal)

--- a/README.md
+++ b/README.md
@@ -193,13 +193,16 @@ loc = torch.zeros(batch_size, event_size)
 
 # Example 1: LDL^T parameterization (numerically stable for precision matrices)
 # Create sparse lower triangular matrix (unit triangular, no diagonal)
+
 scale_tril = rand_sparse_tri(
     (batch_size, event_size, event_size),
     nnz=5000,  # 5000 non-zeros for 1M parameters (0.5% sparsity)
     layout=torch.sparse_csr,
     upper=False,
-    unit_triangular=True  # Unit triangular for LDL^T
+    strict=True  # Strict triangular (exclude diagonal)
 )
+
+scale_tril.requires_grad_(True)
 
 # Diagonal component for LDL^T parameterization
 diagonal = torch.ones(batch_size, event_size) * 0.5
@@ -217,7 +220,7 @@ scale_tril_chol = rand_sparse_tri(
     nnz=5000,
     layout=torch.sparse_csr,
     upper=False,
-    unit_triangular=False  # Include diagonal for LL^T
+    strict=False  # Include diagonal
 )
 
 # Create distribution with LL^T parameterization
@@ -232,7 +235,7 @@ precision_tril = rand_sparse_tri(
     nnz=5000,
     layout=torch.sparse_csr,
     upper=False,
-    unit_triangular=True
+    strict=True
 )
 
 precision_diagonal = torch.ones(batch_size, event_size) * 2.0

--- a/README.md
+++ b/README.md
@@ -196,7 +196,7 @@ loc = torch.zeros(batch_size, event_size)
 
 scale_tril = rand_sparse_tri(
     (batch_size, event_size, event_size),
-    nnz=5000,  # 5000 non-zeros for 1M parameters (0.5% sparsity)
+    nnz=5000,  # 5000 non-zeros for 1000x1000 dense matrix (0.5% sparsity)
     layout=torch.sparse_csr,
     upper=False,
     strict=True  # Strict triangular (exclude diagonal)

--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ batch_size, event_size = 2, 1000
 loc = torch.zeros(batch_size, event_size)
 
 # Example 1: LDL^T parameterization (numerically stable for precision matrices)
-# Create sparse lower triangular matrix (unit triangular, no diagonal)
+# Create sparse lower triangular matrix (strictly lower triangular, no diagonal)
 
 scale_tril = rand_sparse_tri(
     (batch_size, event_size, event_size),
@@ -211,7 +211,7 @@ diagonal = torch.ones(batch_size, event_size) * 0.5
 dist_ldlt = SparseMultivariateNormal(
     loc=loc,
     diagonal=diagonal,
-    scale_tril=scale_tril  # Unit lower triangular
+    scale_tril=scale_tril  # Strictly lower triangular
 )
 
 # Example 2: LL^T parameterization (standard Cholesky)
@@ -243,7 +243,7 @@ precision_diagonal = torch.ones(batch_size, event_size) * 2.0
 dist_precision = SparseMultivariateNormal(
     loc=loc,
     diagonal=precision_diagonal,
-    precision_tril=precision_tril  # Unit triangular precision factor
+    precision_tril=precision_tril  # Strictly triangular precision factor
 )
 
 # Sample with gradient support


### PR DESCRIPTION
Summary

- Replaced the invalid `unit_triangular` parameter with `strict` in the README Quickstart examples to align with the current `rand_sparse_tri()` API.
- Updated example usage to reflect the correct supported parameters.
- Clarified the sparsity comment to accurately describe the generated 1000×1000 dense matrix size and avoid confusion around `event_size=1000`.

Testing

- Verified that the README examples now use the correct `strict` keyword.
- Confirmed the sparsity comment accurately reflects the matrix dimensions and sparsity ratio.


