### PR TITLE
Replace deprecated PyTorch APIs (#94)

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -368,11 +368,11 @@ This benchmark evaluates sparse triangular system solvers with gradient computat
    * - **Code Call**
      - **Description**
      - **Plot Alias**
-   * - ``torch.triangular_solve(B, A.to_dense(), upper=..., unitriangular=..., transpose=...).solution``
+   * - ``torch.linalg.solve_triangular(A.to_dense(), B, upper=..., unitriangular=...)``
      - Dense PyTorch triangular solve baseline operating on a densified copy of the sparse matrix
      - Dense
-   * - ``torch.triangular_solve(B, A, upper=..., unitriangular=..., transpose=...).solution``
-     - PyTorch triangular solve on a sparse input tensor (falls back internally as needed)
+   * - Internal PyTorch sparse compatibility backend
+     - PyTorch's legacy triangular solver on a sparse input tensor, isolated until the linalg API supports sparse CSR
      - torch
    * - ``tsgu.sparse_triangular_solve(A, B, upper=..., unitriangular=..., transpose=...)``
      - torchsparsegradutils sparse triangular solve with gradient support and memory efficiency
@@ -442,7 +442,7 @@ Using the same SuiteSparse matrix ``Rothberg/cfd2`` (shape 123,440 × 123,440, n
 **Conclusions:**
 
 1. Attempting to densify the sparse matrix for ``Dense`` triangular solve leads to OOM errors due to the large memory footprint (≈58 GB for float32, ≈114 GB for float64) on the RTX 4090.
-2. ``torch`` sparse triangular solve on COO layout also fails on backward and forward as torch.triangular_solve does not support sparse COO
+2. The ``torch`` sparse compatibility backend on COO layout fails on forward and backward because the underlying PyTorch solver does not support sparse COO.
 3. ``torch`` sparse triangular solve on CSR layout succeeds on forward pass but fails on backward pass due to internal densification of gradients.
 4. ``CuPy`` triangular solve does provide a sensible memory footprint but has excessive runtime on the backward pass
 5. ``tsgu`` triangular solve provides a good balance of memory efficiency and runtime performance on both forward and backward passes.

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -368,7 +368,7 @@ This benchmark evaluates sparse triangular system solvers with gradient computat
    * - **Code Call**
      - **Description**
      - **Plot Alias**
-   * - ``torch.linalg.solve_triangular(A.to_dense(), B, upper=..., unitriangular=...)``
+   * - ``torch.linalg.solve_triangular(A.to_dense().transpose(-2, -1) if transpose else A.to_dense(), B, upper=not upper if transpose else upper, unitriangular=...)``
      - Dense PyTorch triangular solve baseline operating on a densified copy of the sparse matrix
      - Dense
    * - Internal PyTorch sparse compatibility backend

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -86,7 +86,7 @@ For sparse triangular systems, use :func:`~torchsparsegradutils.sparse_triangula
    # Verify solution (should be close to zero)
    from torchsparsegradutils import sparse_mm
    residual = sparse_mm(L, x) - b
-   print(f"Residual norm: {torch.norm(residual):.6f}")
+   print(f"Residual norm: {torch.linalg.vector_norm(residual):.6f}")
 
 General Linear Systems
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -110,7 +110,7 @@ For general sparse linear systems, use :func:`~torchsparsegradutils.sparse_gener
 
    # Verify solution
    residual = A_sparse @ x_minres - b
-   print(f"MINRES residual norm: {torch.norm(residual):.6f}")
+   print(f"MINRES residual norm: {torch.linalg.vector_norm(residual):.6f}")
 
 Sparse Multivariate Normal Distributions
 -----------------------------------------
@@ -174,8 +174,8 @@ The distributions support reparameterized sampling for gradient computation:
    loss = samples.mean()
    loss.backward()
 
-   print(f"Location gradient norm: {torch.norm(loc.grad):.6f}")
-   print(f"Diagonal gradient norm: {torch.norm(diagonal.grad):.6f}")
+   print(f"Location gradient norm: {torch.linalg.vector_norm(loc.grad):.6f}")
+   print(f"Diagonal gradient norm: {torch.linalg.vector_norm(diagonal.grad):.6f}")
    print(f"Scale gradient nnz: {scale_tril.grad._nnz()}")
 
 Working with Different Backends

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,11 @@ testpaths = [
 pythonpath = [
     "torchsparsegradutils/tests",
 ]
+filterwarnings = [
+    'error:torch\.norm is deprecated.*:UserWarning',
+    'error:torch\.triangular_solve is deprecated.*:UserWarning',
+    'error:.*torch\.jit\.script.*is deprecated.*:DeprecationWarning',
+]
 doctest_optionflags = [
     "NORMALIZE_WHITESPACE",
     "IGNORE_EXCEPTION_DETAIL",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ testpaths = [
 pythonpath = [
     "torchsparsegradutils/tests",
 ]
+# Fail tests when deprecated upstream APIs are exercised outside intentional compatibility paths.
 filterwarnings = [
     'error:torch\.norm is deprecated.*:UserWarning',
     'error:torch\.triangular_solve is deprecated.*:UserWarning',

--- a/torchsparsegradutils/_compat.py
+++ b/torchsparsegradutils/_compat.py
@@ -1,0 +1,36 @@
+"""Compatibility helpers for PyTorch APIs without feature-equivalent replacements."""
+
+import warnings
+
+import torch
+
+
+def sparse_triangular_solve_compat(
+    B: torch.Tensor,
+    A: torch.Tensor,
+    *,
+    upper: bool,
+    unitriangular: bool,
+    transpose: bool,
+) -> torch.Tensor:
+    """Solve a sparse triangular system using PyTorch's legacy sparse backend.
+
+    ``torch.linalg.solve_triangular`` replaces ``torch.triangular_solve`` for
+    dense tensors, but it does not provide the sparse CSR support required by
+    this package. Keep the deprecated call isolated here until a documented,
+    feature-equivalent sparse API is available in every supported PyTorch
+    version.
+    """
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message=r"torch\.triangular_solve is deprecated.*",
+            category=UserWarning,
+        )
+        return torch.triangular_solve(
+            B,
+            A,
+            upper=upper,
+            transpose=transpose,
+            unitriangular=unitriangular,
+        ).solution

--- a/torchsparsegradutils/_compat.py
+++ b/torchsparsegradutils/_compat.py
@@ -5,22 +5,34 @@ import warnings
 import torch
 
 
-def sparse_triangular_solve_compat(
-    B: torch.Tensor,
+def linalg_solve_triangular_compat(
     A: torch.Tensor,
+    B: torch.Tensor,
     *,
     upper: bool,
-    unitriangular: bool,
-    transpose: bool,
+    unitriangular: bool = False,
+    transpose: bool = False,
 ) -> torch.Tensor:
-    """Solve a sparse triangular system using PyTorch's legacy sparse backend.
+    """Solve a triangular system with the appropriate dense or sparse backend.
 
-    ``torch.linalg.solve_triangular`` replaces ``torch.triangular_solve`` for
-    dense tensors, but it does not provide the sparse CSR support required by
-    this package. Keep the deprecated call isolated here until a documented,
-    feature-equivalent sparse API is available in every supported PyTorch
-    version.
+    Dense coefficient matrices use ``torch.linalg.solve_triangular``. Sparse
+    matrices continue to use the isolated legacy call because the replacement
+    API does not support the sparse layouts required by this package. See
+    https://github.com/pytorch/pytorch/issues/87358 for upstream sparse feature
+    parity tracking.
     """
+    if A.layout == torch.strided:
+        if transpose:
+            A = A.transpose(-2, -1)
+            upper = not upper
+
+        return torch.linalg.solve_triangular(
+            A,
+            B,
+            upper=upper,
+            unitriangular=unitriangular,
+        )
+
     with warnings.catch_warnings():
         warnings.filterwarnings(
             "ignore",

--- a/torchsparsegradutils/benchmarks/sparse_generic_solve_rand.py
+++ b/torchsparsegradutils/benchmarks/sparse_generic_solve_rand.py
@@ -225,8 +225,8 @@ def run_sparse_generic_solve_benchmark():
                                 else:
                                     residual = A_sparse @ x - B
 
-                                resnorm = torch.norm(residual).cpu().item()
-                                B_norm = torch.norm(B).cpu().item()
+                                resnorm = torch.linalg.vector_norm(residual).cpu().item()
+                                B_norm = torch.linalg.vector_norm(B).cpu().item()
                                 relative_resnorm = resnorm / B_norm if B_norm > 0 else 0.0
 
                             # Print result with residual norm

--- a/torchsparsegradutils/benchmarks/sparse_generic_solve_suite.py
+++ b/torchsparsegradutils/benchmarks/sparse_generic_solve_suite.py
@@ -201,10 +201,9 @@ def run_sparse_solve_benchmark():
                         with torch.no_grad():
                             x = alg_fn(A_sparse, B)
                             residual = A_sparse @ x - B
-                            resnorm = torch.norm(residual).cpu().item()
-                            relative_resnorm = (
-                                resnorm / torch.norm(B).cpu().item() if torch.norm(B).cpu().item() > 0 else 0.0
-                            )
+                            resnorm = torch.linalg.vector_norm(residual).cpu().item()
+                            B_norm = torch.linalg.vector_norm(B).cpu().item()
+                            relative_resnorm = resnorm / B_norm if B_norm > 0 else 0.0
 
                         # Print result with residual norm
                         print_result_row(

--- a/torchsparsegradutils/benchmarks/sparse_triangular_solve_rand.py
+++ b/torchsparsegradutils/benchmarks/sparse_triangular_solve_rand.py
@@ -27,6 +27,7 @@ from cupyx.scipy.sparse.linalg._solve import spsolve_triangular
 from tqdm import tqdm
 
 from torchsparsegradutils import sparse_triangular_solve
+from torchsparsegradutils._compat import sparse_triangular_solve_compat
 from torchsparsegradutils.cupy.cupy_sparse_solve import sparse_solve_c4t
 from torchsparsegradutils.utils import rand_sparse, rand_sparse_tri
 
@@ -58,16 +59,19 @@ LAYOUTS = [torch.sparse_coo, torch.sparse_csr]
 
 ALGORITHMS = [
     (
-        "dense.triangular_solve",
-        lambda A, B: torch.triangular_solve(
-            B, A.to_dense(), upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
-        ).solution,
+        "dense.linalg.solve_triangular",
+        lambda A, B: torch.linalg.solve_triangular(
+            A.to_dense().transpose(-2, -1) if TRANSPOSE else A.to_dense(),
+            B,
+            upper=not UPPER if TRANSPOSE else UPPER,
+            unitriangular=UNITRIANGULAR,
+        ),
     ),
     (
-        "torch_triangular_solve",
-        lambda A, B: torch.triangular_solve(
+        "torch_sparse_triangular_solve_compat",
+        lambda A, B: sparse_triangular_solve_compat(
             B, A, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
-        ).solution,
+        ),
     ),
     (
         "sparse_triangular_solve",
@@ -153,8 +157,8 @@ def run_sparse_triangular_solve_benchmark():
                             with torch.no_grad():
                                 x = alg_fn(A_sparse, B)
                                 residual = A_sparse @ x - B
-                                resnorm = torch.norm(residual).cpu().item()
-                                relative_resnorm = resnorm / torch.norm(B).cpu().item()
+                                resnorm = torch.linalg.vector_norm(residual).cpu().item()
+                                relative_resnorm = resnorm / torch.linalg.vector_norm(B).cpu().item()
 
                             # # Calculate residual norm for solution accuracy
                             # with torch.no_grad():
@@ -165,8 +169,8 @@ def run_sparse_triangular_solve_benchmark():
                             #     else:
                             #         Ax = A_sparse @ x
                             #     residual = Ax - B
-                            #     resnorm = torch.norm(residual).cpu().item()
-                            #     relative_resnorm = resnorm / torch.norm(B).cpu().item()
+                            #     resnorm = torch.linalg.vector_norm(residual).cpu().item()
+                            #     relative_resnorm = resnorm / torch.linalg.vector_norm(B).cpu().item()
 
                             # Print result with residual norm
                             print_result_row(

--- a/torchsparsegradutils/benchmarks/sparse_triangular_solve_rand.py
+++ b/torchsparsegradutils/benchmarks/sparse_triangular_solve_rand.py
@@ -27,7 +27,7 @@ from cupyx.scipy.sparse.linalg._solve import spsolve_triangular
 from tqdm import tqdm
 
 from torchsparsegradutils import sparse_triangular_solve
-from torchsparsegradutils._compat import sparse_triangular_solve_compat
+from torchsparsegradutils._compat import linalg_solve_triangular_compat
 from torchsparsegradutils.cupy.cupy_sparse_solve import sparse_solve_c4t
 from torchsparsegradutils.utils import rand_sparse, rand_sparse_tri
 
@@ -68,9 +68,9 @@ ALGORITHMS = [
         ),
     ),
     (
-        "torch_sparse_triangular_solve_compat",
-        lambda A, B: sparse_triangular_solve_compat(
-            B, A, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
+        "linalg_solve_triangular_compat",
+        lambda A, B: linalg_solve_triangular_compat(
+            A, B, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
         ),
     ),
     (

--- a/torchsparsegradutils/benchmarks/sparse_triangular_solve_suitesparse.py
+++ b/torchsparsegradutils/benchmarks/sparse_triangular_solve_suitesparse.py
@@ -34,7 +34,7 @@ from cupyx.scipy.sparse.linalg._solve import spsolve_triangular
 from tqdm import tqdm
 
 from torchsparsegradutils import sparse_triangular_solve
-from torchsparsegradutils._compat import sparse_triangular_solve_compat
+from torchsparsegradutils._compat import linalg_solve_triangular_compat
 from torchsparsegradutils.cupy.cupy_sparse_solve import sparse_solve_c4t
 
 # from jax.lax.linalg import triangular_solve  # NOTE: jax doesn't have a sparse triangular solve
@@ -67,9 +67,9 @@ ALGORITHMS = [
         ),
     ),
     (
-        "torch_sparse_triangular_solve_compat",
-        lambda A, B: sparse_triangular_solve_compat(
-            B, A, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
+        "linalg_solve_triangular_compat",
+        lambda A, B: linalg_solve_triangular_compat(
+            A, B, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
         ),
     ),
     (

--- a/torchsparsegradutils/benchmarks/sparse_triangular_solve_suitesparse.py
+++ b/torchsparsegradutils/benchmarks/sparse_triangular_solve_suitesparse.py
@@ -34,6 +34,7 @@ from cupyx.scipy.sparse.linalg._solve import spsolve_triangular
 from tqdm import tqdm
 
 from torchsparsegradutils import sparse_triangular_solve
+from torchsparsegradutils._compat import sparse_triangular_solve_compat
 from torchsparsegradutils.cupy.cupy_sparse_solve import sparse_solve_c4t
 
 # from jax.lax.linalg import triangular_solve  # NOTE: jax doesn't have a sparse triangular solve
@@ -57,16 +58,19 @@ LAYOUTS = [torch.sparse_coo, torch.sparse_csr]
 
 ALGORITHMS = [
     (
-        "dense.triangular_solve",
-        lambda A, B: torch.triangular_solve(
-            B, A.to_dense(), upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
-        ).solution,
+        "dense.linalg.solve_triangular",
+        lambda A, B: torch.linalg.solve_triangular(
+            A.to_dense().transpose(-2, -1) if TRANSPOSE else A.to_dense(),
+            B,
+            upper=not UPPER if TRANSPOSE else UPPER,
+            unitriangular=UNITRIANGULAR,
+        ),
     ),
     (
-        "torch_triangular_solve",
-        lambda A, B: torch.triangular_solve(
+        "torch_sparse_triangular_solve_compat",
+        lambda A, B: sparse_triangular_solve_compat(
             B, A, upper=UPPER, unitriangular=UNITRIANGULAR, transpose=TRANSPOSE
-        ).solution,
+        ),
     ),
     (
         "sparse_triangular_solve",
@@ -185,10 +189,9 @@ def run_triangular_solve_benchmark():
                             # Use the triangular matrix A_sparse (not A_full) for residual calculation
                             # This ensures the residual is computed correctly for the actual triangular system solved
                             residual = A_sparse @ x - B
-                            resnorm = torch.norm(residual).cpu().item()
-                            relative_resnorm = (
-                                resnorm / torch.norm(B).cpu().item() if torch.norm(B).cpu().item() > 0 else 0.0
-                            )
+                            resnorm = torch.linalg.vector_norm(residual).cpu().item()
+                            B_norm = torch.linalg.vector_norm(B).cpu().item()
+                            relative_resnorm = resnorm / B_norm if B_norm > 0 else 0.0
 
                         # Print result
                         print_result_row(

--- a/torchsparsegradutils/sparse_solve.py
+++ b/torchsparsegradutils/sparse_solve.py
@@ -3,6 +3,7 @@ from typing import Callable, Optional, cast
 
 import torch
 
+from torchsparsegradutils._compat import sparse_triangular_solve_compat
 from torchsparsegradutils.utils import convert_coo_to_csr, sparse_block_diag, sparse_block_diag_split, stack_csr
 
 
@@ -154,7 +155,7 @@ class SparseTriangularSolve(torch.autograd.Function):
     See Also
     --------
     sparse_triangular_solve : User-facing function that calls this autograd function.
-    torch.triangular_solve : PyTorch's native triangular solver.
+    torch.linalg.solve_triangular : PyTorch's native dense triangular solver.
     """
 
     @staticmethod
@@ -177,11 +178,9 @@ class SparseTriangularSolve(torch.autograd.Function):
             A = convert_coo_to_csr(A)  # NOTE: triangular solve doesn't work with sparse coo
             ctx.csr = False
 
-        # NOTE: DEPRECATED: Check if a workaround for https://github.com/pytorch/pytorch/issues/88890 is needed
-
-        x = torch.triangular_solve(
+        x = sparse_triangular_solve_compat(
             B.detach(), A.detach(), upper=upper, unitriangular=unitriangular, transpose=transpose
-        ).solution
+        )
 
         x.requires_grad = grad_flag
         ctx.save_for_backward(A, x.detach())
@@ -199,11 +198,10 @@ class SparseTriangularSolve(torch.autograd.Function):
         A, x = ctx.saved_tensors
 
         # Backprop rule: gradB = A^{-T} grad
-        # NOTE: DEPRECATED: Check if a workaround for https://github.com/pytorch/pytorch/issues/88890 is needed
 
-        gradB = torch.triangular_solve(
+        gradB = sparse_triangular_solve_compat(
             grad, A, upper=ctx.upper, transpose=not ctx.transpose, unitriangular=ctx.unitriangular
-        ).solution
+        )
 
         # The gradient with respect to the matrix A seen as a dense matrix would
         # lead to a backprop rule as follows

--- a/torchsparsegradutils/sparse_solve.py
+++ b/torchsparsegradutils/sparse_solve.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional, cast
 
 import torch
 
-from torchsparsegradutils._compat import sparse_triangular_solve_compat
+from torchsparsegradutils._compat import linalg_solve_triangular_compat
 from torchsparsegradutils.utils import convert_coo_to_csr, sparse_block_diag, sparse_block_diag_split, stack_csr
 
 
@@ -178,8 +178,8 @@ class SparseTriangularSolve(torch.autograd.Function):
             A = convert_coo_to_csr(A)  # NOTE: triangular solve doesn't work with sparse coo
             ctx.csr = False
 
-        x = sparse_triangular_solve_compat(
-            B.detach(), A.detach(), upper=upper, unitriangular=unitriangular, transpose=transpose
+        x = linalg_solve_triangular_compat(
+            A.detach(), B.detach(), upper=upper, unitriangular=unitriangular, transpose=transpose
         )
 
         x.requires_grad = grad_flag
@@ -199,8 +199,8 @@ class SparseTriangularSolve(torch.autograd.Function):
 
         # Backprop rule: gradB = A^{-T} grad
 
-        gradB = sparse_triangular_solve_compat(
-            grad, A, upper=ctx.upper, transpose=not ctx.transpose, unitriangular=ctx.unitriangular
+        gradB = linalg_solve_triangular_compat(
+            A, grad, upper=ctx.upper, transpose=not ctx.transpose, unitriangular=ctx.unitriangular
         )
 
         # The gradient with respect to the matrix A seen as a dense matrix would

--- a/torchsparsegradutils/tests/test_deprecated_torch_apis.py
+++ b/torchsparsegradutils/tests/test_deprecated_torch_apis.py
@@ -1,0 +1,62 @@
+"""Regression checks for deprecated upstream PyTorch APIs."""
+
+import ast
+import re
+from pathlib import Path
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+PACKAGE_ROOT = REPOSITORY_ROOT / "torchsparsegradutils"
+COMPATIBILITY_MODULE = Path("_compat.py")
+DEPRECATED_DOCUMENTATION_NORM = re.compile(r"(?<![\w.])torch\.norm\s*\(")
+
+
+def attribute_name(node):
+    parts = []
+    while isinstance(node, ast.Attribute):
+        parts.append(node.attr)
+        node = node.value
+    if isinstance(node, ast.Name):
+        parts.append(node.id)
+    return ".".join(reversed(parts))
+
+
+def test_deprecated_torch_calls_are_not_reintroduced():
+    violations = []
+    compatibility_calls = []
+
+    for path in PACKAGE_ROOT.rglob("*.py"):
+        relative_path = path.relative_to(PACKAGE_ROOT)
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+
+        for node in ast.walk(tree):
+            location = f"{relative_path}:{getattr(node, 'lineno', '?')}"
+            if isinstance(node, ast.Attribute) and attribute_name(node) == "torch.jit.script":
+                violations.append(location)
+
+            if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Attribute):
+                continue
+
+            call_name = attribute_name(node.func)
+            if call_name == "torch.norm":
+                violations.append(location)
+            elif call_name == "torch.triangular_solve":
+                if relative_path == COMPATIBILITY_MODULE:
+                    compatibility_calls.append(location)
+                else:
+                    violations.append(location)
+
+    assert not violations, "Deprecated PyTorch APIs found:\n" + "\n".join(violations)
+    assert len(compatibility_calls) == 1, "Expected one isolated sparse triangular compatibility call"
+
+
+def test_documentation_does_not_use_deprecated_norm_apis():
+    violations = []
+    documentation_paths = [REPOSITORY_ROOT / "README.md"]
+    documentation_paths.extend((REPOSITORY_ROOT / "docs").rglob("*.md"))
+    documentation_paths.extend((REPOSITORY_ROOT / "docs").rglob("*.rst"))
+
+    for path in documentation_paths:
+        if DEPRECATED_DOCUMENTATION_NORM.search(path.read_text(encoding="utf-8")):
+            violations.append(str(path.relative_to(REPOSITORY_ROOT)))
+
+    assert not violations, "Deprecated norm examples found:\n" + "\n".join(violations)

--- a/torchsparsegradutils/tests/test_integration_pairwise_sparse_mvn.py
+++ b/torchsparsegradutils/tests/test_integration_pairwise_sparse_mvn.py
@@ -360,7 +360,7 @@ def run_forward_backward_iterations(
 
         # Record gradient statistics
         if params.grad is not None:
-            grad_norm = params.grad.norm().item()
+            grad_norm = torch.linalg.vector_norm(params.grad).item()
             grad_max = params.grad.abs().max().item()
             grad_mean = params.grad.abs().mean().item()
 
@@ -505,7 +505,7 @@ def test_integration_gradient_flow_consistency_2d(
         # Backward pass
         loss.backward()
 
-        gradient_norms.append(params.grad.norm().item())
+        gradient_norms.append(torch.linalg.vector_norm(params.grad).item())
 
         # Zero gradients
         params.grad.zero_()
@@ -551,7 +551,7 @@ def test_integration_gradient_flow_consistency_3d(
         # Backward pass
         loss.backward()
 
-        gradient_norms.append(params.grad.norm().item())
+        gradient_norms.append(torch.linalg.vector_norm(params.grad).item())
 
         # Zero gradients
         params.grad.zero_()
@@ -591,7 +591,7 @@ def test_integration_parameter_optimization_2d(
 
     # Optimization loop
     optimizer = torch.optim.Adam([params], lr=0.01)
-    initial_param_norm = params.norm().item()
+    initial_param_norm = torch.linalg.vector_norm(params).item()
 
     for _ in range(10):
         optimizer.zero_grad()
@@ -611,7 +611,7 @@ def test_integration_parameter_optimization_2d(
         optimizer.step()
 
     # Check that parameters changed
-    final_param_norm = params.norm().item()
+    final_param_norm = torch.linalg.vector_norm(params).item()
     param_change = abs(final_param_norm - initial_param_norm) / initial_param_norm
 
     assert param_change > 0.01, f"Parameters barely changed: {param_change:.6f}"
@@ -642,7 +642,7 @@ def test_integration_parameter_optimization_3d(
 
     # Optimization loop
     optimizer = torch.optim.Adam([params], lr=0.01)
-    initial_param_norm = params.norm().item()
+    initial_param_norm = torch.linalg.vector_norm(params).item()
 
     for _ in range(10):
         optimizer.zero_grad()
@@ -662,7 +662,7 @@ def test_integration_parameter_optimization_3d(
         optimizer.step()
 
     # Check that parameters changed
-    final_param_norm = params.norm().item()
+    final_param_norm = torch.linalg.vector_norm(params).item()
     param_change = abs(final_param_norm - initial_param_norm) / initial_param_norm
 
     assert param_change > 0.01, f"Parameters barely changed: {param_change:.6f}"

--- a/torchsparsegradutils/tests/test_linear_cg.py
+++ b/torchsparsegradutils/tests/test_linear_cg.py
@@ -10,7 +10,7 @@ def test_cg():
     # SPD matrix
     matrix = torch.randn(size, size, dtype=torch.float64)
     matrix = matrix.matmul(matrix.mT)
-    matrix.div_(matrix.norm()).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
+    matrix.div_(torch.linalg.vector_norm(matrix)).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
     # single RHS
     rhs = torch.randn(size, dtype=torch.float64)
     solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
@@ -36,7 +36,7 @@ def test_cg_with_tridiag():
     size = 10
     matrix = torch.randn(size, size, dtype=torch.float64)
     matrix = matrix.matmul(matrix.mT)
-    matrix.div_(matrix.norm()).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
+    matrix.div_(torch.linalg.vector_norm(matrix)).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
     rhs = torch.randn(size, 50, dtype=torch.float64)
     solves, t_mats = linear_cg(
         matrix.matmul, rhs=rhs, n_tridiag=5, max_tridiag_iter=10, max_iter=size, tolerance=0, eps=1e-15
@@ -57,7 +57,7 @@ def test_batch_cg(batch):
     shape = (batch, size, size) if batch else (size, size)
     matrix = torch.randn(*shape, dtype=torch.float64)
     matrix = matrix.matmul(matrix.mT)
-    matrix.div_(matrix.norm()).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
+    matrix.div_(torch.linalg.vector_norm(matrix)).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
     b_shape = (batch, size, 50) if batch else (size, 50)
     rhs = torch.randn(*b_shape, dtype=torch.float64)
     solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size)
@@ -72,7 +72,7 @@ def test_batch_cg_with_tridiag(batch):
     shape = (batch, size, size) if batch else (size, size)
     matrix = torch.randn(*shape, dtype=torch.float64)
     matrix = matrix.matmul(matrix.mT)
-    matrix.div_(matrix.norm()).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
+    matrix.div_(torch.linalg.vector_norm(matrix)).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
     b_shape = (batch, size, 10) if batch else (size, 10)
     rhs = torch.randn(*b_shape, dtype=torch.float64)
     solves, t_mats = linear_cg(
@@ -95,7 +95,7 @@ def test_batch_cg_init():
     size = 100
     matrix = torch.randn(batch, size, size, dtype=torch.float64)
     matrix = matrix.matmul(matrix.mT)
-    matrix.div_(matrix.norm()).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
+    matrix.div_(torch.linalg.vector_norm(matrix)).add_(torch.eye(size, dtype=torch.float64) * 1e-1)
     rhs = torch.randn(batch, size, 50, dtype=torch.float64)
     solves = linear_cg(matrix.matmul, rhs=rhs, max_iter=size, max_tridiag_iter=0)
     solves_init = linear_cg(matrix.matmul, rhs=rhs, max_iter=1, initial_guess=solves, max_tridiag_iter=0)

--- a/torchsparsegradutils/tests/test_minres.py
+++ b/torchsparsegradutils/tests/test_minres.py
@@ -18,7 +18,7 @@ def _run_minres(rhs_shape, shifts=None, matrix_batch_shape=torch.Size([])):
     rhs = torch.randn(rhs_shape, dtype=torch.float64)
     matrix = torch.randn(*matrix_batch_shape, size, size, dtype=torch.float64)
     matrix = matrix @ matrix.mT
-    matrix = matrix / matrix.norm()
+    matrix = matrix / torch.linalg.vector_norm(matrix)
     matrix = matrix + torch.eye(size, dtype=torch.float64) * 1e-1
     # compute minres
     if shifts is not None:

--- a/torchsparsegradutils/tests/test_quickstart_guide.py
+++ b/torchsparsegradutils/tests/test_quickstart_guide.py
@@ -5,13 +5,8 @@ This module tests all code examples from the quickstart documentation to ensure 
 It is integrated with pytest and runs as part of the CI pipeline.
 """
 
-import warnings
-
 import pytest
 import torch
-
-# Suppress warnings for cleaner test output
-warnings.filterwarnings("ignore")
 
 
 def test_sparse_mm_example():
@@ -76,7 +71,7 @@ def test_triangular_solve():
 
     # Verify solution (should be close to zero)
     residual = sparse_mm(L, x) - b
-    residual_norm = torch.norm(residual)
+    residual_norm = torch.linalg.vector_norm(residual)
     assert residual_norm < 1e-5, f"Residual too large: {residual_norm}"
 
 
@@ -97,7 +92,7 @@ def test_generic_solve():
 
     # Verify solution
     residual = A_sparse @ x_cg - b
-    residual_norm = torch.norm(residual)
+    residual_norm = torch.linalg.vector_norm(residual)
     assert residual_norm < 1e-4, f"Residual too large: {residual_norm}"
 
 

--- a/torchsparsegradutils/tests/test_random.py
+++ b/torchsparsegradutils/tests/test_random.py
@@ -662,7 +662,7 @@ def test_make_spd_sparse_solve_system(device):
     try:
         x_dense = torch.linalg.solve(A_dense, b)
         residual = A_dense @ x_dense - b
-        residual_norm = torch.norm(residual).item()
+        residual_norm = torch.linalg.vector_norm(residual).item()
 
         # Check that residual is small
         assert residual_norm < 1e-10, f"Dense solve residual too large: {residual_norm}"

--- a/torchsparsegradutils/tests/test_sparse_triangular_solve.py
+++ b/torchsparsegradutils/tests/test_sparse_triangular_solve.py
@@ -1,11 +1,13 @@
 import sys
 import warnings
+from unittest.mock import patch
 
 import pytest
 import torch
 from test_config import DEVICES, INDEX_DTYPES, VALUE_DTYPES, Tolerances
 
 from torchsparsegradutils import sparse_triangular_solve
+from torchsparsegradutils._compat import linalg_solve_triangular_compat
 from torchsparsegradutils.utils import rand_sparse_tri
 
 TEST_DATA = [
@@ -201,6 +203,61 @@ def test_sparse_triangular_solve_does_not_emit_upstream_deprecation_warning():
         warning for warning in caught_warnings if "triangular_solve is deprecated" in str(warning.message)
     ]
     assert not deprecation_warnings
+
+
+@pytest.mark.parametrize("transpose", TRANSPOSE, ids=[transpose_id(d) for d in TRANSPOSE])
+def test_linalg_solve_triangular_compat_dispatches_dense_to_modern_backend(transpose):
+    A_dense = torch.tensor(
+        [[2.0, 0.0, 0.0], [1.0, 3.0, 0.0], [4.0, 5.0, 6.0]],
+        dtype=torch.float64,
+    )
+    B = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.float64)
+    expected = dense_triangular_solve(
+        A_dense,
+        B,
+        upper=False,
+        unitriangular=False,
+        transpose=transpose,
+    )
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        with patch("torch.linalg.solve_triangular", wraps=torch.linalg.solve_triangular) as modern_solve:
+            with patch("torch.triangular_solve", wraps=torch.triangular_solve) as legacy_solve:
+                result = linalg_solve_triangular_compat(A_dense, B, upper=False, transpose=transpose)
+
+    torch.testing.assert_close(result, expected)
+    modern_solve.assert_called_once()
+    legacy_solve.assert_not_called()
+    assert not [warning for warning in caught_warnings if "triangular_solve is deprecated" in str(warning.message)]
+
+
+@pytest.mark.parametrize("transpose", TRANSPOSE, ids=[transpose_id(d) for d in TRANSPOSE])
+def test_sparse_triangular_solve_dispatches_sparse_to_legacy_backend(layout, transpose):
+    A_dense = torch.tensor(
+        [[2.0, 0.0, 0.0], [1.0, 3.0, 0.0], [4.0, 5.0, 6.0]],
+        dtype=torch.float64,
+    )
+    A = A_dense.to_sparse() if layout == torch.sparse_coo else A_dense.to_sparse_csr()
+    B = torch.tensor([[1.0, 2.0], [3.0, 4.0], [5.0, 6.0]], dtype=torch.float64)
+    expected = dense_triangular_solve(
+        A_dense,
+        B,
+        upper=False,
+        unitriangular=False,
+        transpose=transpose,
+    )
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        with patch("torch.linalg.solve_triangular", wraps=torch.linalg.solve_triangular) as modern_solve:
+            with patch("torch.triangular_solve", wraps=torch.triangular_solve) as legacy_solve:
+                result = sparse_triangular_solve(A, B, upper=False, transpose=transpose)
+
+    torch.testing.assert_close(result, expected)
+    modern_solve.assert_not_called()
+    legacy_solve.assert_called_once()
+    assert not [warning for warning in caught_warnings if "triangular_solve is deprecated" in str(warning.message)]
 
 
 def test_torch_linalg_solve_triangular_rejects_sparse_csr():

--- a/torchsparsegradutils/tests/test_sparse_triangular_solve.py
+++ b/torchsparsegradutils/tests/test_sparse_triangular_solve.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import pytest
 import torch
@@ -49,6 +50,19 @@ def transpose_id(transpose):
 
 def layout_id(layout):
     return "coo" if layout == torch.sparse_coo else "csr"
+
+
+def dense_triangular_solve(A, B, *, upper, unitriangular, transpose):
+    if transpose:
+        A = A.transpose(-2, -1)
+        upper = not upper
+
+    return torch.linalg.solve_triangular(
+        A,
+        B,
+        upper=upper,
+        unitriangular=unitriangular,
+    )
 
 
 # Define Fixtures
@@ -115,7 +129,7 @@ def test_tri_solve_forward_routine(layout, device, value_dtype, index_dtype, sha
     B = torch.rand(*B_shape, dtype=value_dtype, device=device)
     Ad = A.to_dense()
 
-    res_ref = torch.triangular_solve(B, Ad, upper=upper, unitriangular=unitriangular, transpose=transpose).solution
+    res_ref = dense_triangular_solve(Ad, B, upper=upper, unitriangular=unitriangular, transpose=transpose)
     res_test = sparse_triangular_solve(A, B, upper=upper, unitriangular=unitriangular, transpose=transpose)
 
     atol, rtol = Tolerances.direct(value_dtype)
@@ -139,108 +153,62 @@ def test_tri_solve_backward_routine(layout, device, value_dtype, index_dtype, sh
         device=device,
     )
 
-    Ad2 = As1.to_dense().detach().clone()  # detach and clone to create seperate graph
-    Ad3 = Ad2.detach().clone()
+    Ad_ref = As1.to_dense().detach().clone()
 
     Bd1 = torch.rand(*B_shape, dtype=value_dtype, device=device)
-    Bd2 = Bd1.detach().clone()
-    Bd3 = Bd1.detach().clone()
+    Bd_ref = Bd1.detach().clone()
 
     As1.requires_grad_()
-    Ad2.requires_grad_()
-    Ad3.requires_grad_()
+    Ad_ref.requires_grad_()
     Bd1.requires_grad_()
-    Bd2.requires_grad_()
-    Bd3.requires_grad_()
+    Bd_ref.requires_grad_()
 
-    res_ref = torch.triangular_solve(Bd2, Ad2, upper=upper, unitriangular=unitriangular, transpose=transpose).solution
+    res_ref = dense_triangular_solve(Ad_ref, Bd_ref, upper=upper, unitriangular=unitriangular, transpose=transpose)
     res_test = sparse_triangular_solve(As1, Bd1, upper=upper, unitriangular=unitriangular, transpose=transpose)
-
-    # Let's add another test to make sure that the transpose argument is working as epexcted:
-    if transpose:
-        res_test2 = torch.linalg.solve_triangular(
-            Ad3.transpose(-2, -1), Bd3, upper=not upper, unitriangular=unitriangular
-        )
-    else:
-        res_test2 = torch.linalg.solve_triangular(Ad3, Bd3, upper=upper, unitriangular=unitriangular)
 
     # Generate random gradients for the backward pass
     grad_output = torch.rand_like(res_test, dtype=value_dtype, device=device)
 
     res_ref.backward(grad_output)
     res_test.backward(grad_output)
-    res_test2.backward(grad_output)
 
     nz_mask = As1.grad.to_dense() != 0.0
 
     atol, rtol = Tolerances.direct(value_dtype)
-    assert torch.allclose(As1.grad.to_dense()[nz_mask], Ad2.grad[nz_mask], atol=atol, rtol=rtol)
-    assert torch.allclose(As1.grad.to_dense()[nz_mask], Ad3.grad[nz_mask], atol=atol, rtol=rtol)
+    assert torch.allclose(As1.grad.to_dense()[nz_mask], Ad_ref.grad[nz_mask], atol=atol, rtol=rtol)
 
-    assert torch.allclose(Bd1.grad, Bd2.grad, atol=atol, rtol=rtol)
-    assert torch.allclose(Bd1.grad, Bd3.grad, atol=atol, rtol=rtol)
+    assert torch.allclose(Bd1.grad, Bd_ref.grad, atol=atol, rtol=rtol)
 
 
-def test_torch_triangular_solve_backward_fail(
-    layout, device, value_dtype, index_dtype, shapes, upper, unitriangular, transpose
-):
-    if sys.platform == "win32" and device == torch.device("cpu"):
-        pytest.skip("Skipping backward failure test on Windows CPU")
-    # unpack shapes
-    _, A_shape, B_shape, A_nnz = shapes
-    # create a random sparse triangular A and a dense B
-    As1 = rand_sparse_tri(
-        A_shape,
-        A_nnz,
-        layout,
-        upper=upper,
-        strict=unitriangular,
-        indices_dtype=index_dtype,
-        values_dtype=value_dtype,
-        device=device,
+def test_sparse_triangular_solve_does_not_emit_upstream_deprecation_warning():
+    A = rand_sparse_tri(
+        (4, 4),
+        6,
+        torch.sparse_csr,
+        upper=False,
+        strict=False,
+        indices_dtype=torch.int64,
+        values_dtype=torch.float64,
+        device=torch.device("cpu"),
     )
-    Bd1 = torch.rand(*B_shape, dtype=value_dtype, device=device)
-    Ad = As1.to_dense()
-    # torch.triangular_solve does not support backward on general inputs
-    with pytest.raises(RuntimeError):
-        sol = torch.triangular_solve(Bd1, Ad, upper=upper, unitriangular=unitriangular, transpose=transpose).solution
-        sol.sum().backward()
+    B = torch.rand(4, 2, dtype=torch.float64)
+
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        sparse_triangular_solve(A, B, upper=False)
+
+    deprecation_warnings = [
+        warning for warning in caught_warnings if "triangular_solve is deprecated" in str(warning.message)
+    ]
+    assert not deprecation_warnings
 
 
-def test_torch_linalg_solve_triangular_backward_fail(
-    layout, device, value_dtype, index_dtype, shapes, upper, unitriangular, transpose
-):
-    if sys.platform == "win32" and device == torch.device("cpu"):
-        pytest.skip("Skipping backward failure test on Windows CPU")
-    _, A_shape, B_shape, A_nnz = shapes
-    As1 = rand_sparse_tri(
-        A_shape,
-        A_nnz,
-        layout,
-        upper=upper,
-        strict=unitriangular,
-        indices_dtype=index_dtype,
-        values_dtype=value_dtype,
-        device=device,
-    )
-    Bd1 = torch.rand(*B_shape, dtype=value_dtype, device=device)
-    Ad = As1.to_dense()
-    with pytest.raises(RuntimeError):
-        if transpose:
-            sol = torch.linalg.solve_triangular(
-                Ad.transpose(-2, -1),
-                Bd1,
-                upper=not upper,
-                unitriangular=unitriangular,
-            )
-        else:
-            sol = torch.linalg.solve_triangular(
-                Ad,
-                Bd1,
-                upper=upper,
-                unitriangular=unitriangular,
-            )
-        sol.sum().backward()
+def test_torch_linalg_solve_triangular_rejects_sparse_csr():
+    A = torch.eye(4, dtype=torch.float64).to_sparse_csr()
+    B = torch.ones(4, 2, dtype=torch.float64)
+
+    with pytest.raises(NotImplementedError, match="SparseCsr"):
+        torch.linalg.solve_triangular(A, B, upper=False)
 
 
 def test_sparse_triangular_solve_optimize_A_multiple_steps(layout, device, value_dtype, index_dtype):

--- a/torchsparsegradutils/utils/linear_cg.py
+++ b/torchsparsegradutils/utils/linear_cg.py
@@ -24,8 +24,7 @@ def _default_preconditioner(x):
     return x.clone()
 
 
-@torch.jit.script
-def _jit_linear_cg_updates(
+def _linear_cg_updates(
     result, alpha, residual_inner_prod, eps, beta, residual, precond_residual, mul_storage, is_zero, curr_conjugate_vec
 ):
     # # Update result
@@ -48,8 +47,7 @@ def _jit_linear_cg_updates(
     curr_conjugate_vec.mul_(beta).add_(precond_residual)
 
 
-@torch.jit.script
-def _jit_linear_cg_updates_no_precond(
+def _linear_cg_updates_no_precond(
     mvms,
     result,
     has_converged,
@@ -83,7 +81,7 @@ def _jit_linear_cg_updates_no_precond(
     # precon_residual{k} = M^-1 residual_{k}
     precond_residual = residual.clone()
 
-    _jit_linear_cg_updates(
+    _linear_cg_updates(
         result,
         alpha,
         residual_inner_prod,
@@ -256,7 +254,7 @@ def linear_cg(
     # Get the norm of the rhs - used for convergence checks
     # Here we're going to make almost-zero norms actually be 1 (so we don't get divide-by-zero issues)
     # But we'll store which norms were actually close to zero
-    rhs_norm = rhs.norm(2, dim=-2, keepdim=True)
+    rhs_norm = torch.linalg.vector_norm(rhs, ord=2, dim=-2, keepdim=True)
     rhs_is_zero = rhs_norm.lt(eps)
     rhs_norm = rhs_norm.masked_fill_(rhs_is_zero, 1)
 
@@ -282,7 +280,7 @@ def linear_cg(
 
     # Sometime we're lucky and the preconditioner solves the system right away
     # Check for convergence
-    residual_norm = residual.norm(2, dim=-2, keepdim=True)
+    residual_norm = torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True)
     has_converged = torch.lt(residual_norm, stop_updating_after)
 
     if has_converged.all() and not n_tridiag:
@@ -343,7 +341,7 @@ def linear_cg(
             # precon_residual{k} = M^-1 residual_{k}
             precond_residual = preconditioner(residual)
 
-            _jit_linear_cg_updates(
+            _linear_cg_updates(
                 result,
                 alpha,
                 residual_inner_prod,
@@ -356,7 +354,7 @@ def linear_cg(
                 curr_conjugate_vec,
             )
         else:
-            _jit_linear_cg_updates_no_precond(
+            _linear_cg_updates_no_precond(
                 mvms,
                 result,
                 has_converged,
@@ -371,7 +369,7 @@ def linear_cg(
                 curr_conjugate_vec,
             )
 
-        torch.norm(residual, 2, dim=-2, keepdim=True, out=residual_norm)
+        torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True, out=residual_norm)
         residual_norm.masked_fill_(rhs_is_zero, 0)
         torch.lt(residual_norm, stop_updating_after, out=has_converged)
 

--- a/torchsparsegradutils/utils/lsmr.py
+++ b/torchsparsegradutils/utils/lsmr.py
@@ -181,19 +181,19 @@ def lsmr(
         maxiter = min(m, n)
 
     u = b.clone()
-    normb = b.norm()
+    normb = torch.linalg.vector_norm(b)
     if x0 is None:
         x = b.new_zeros(n)
         beta = normb.clone()
     else:
         x = torch.atleast_1d(x0).clone()
         u.sub_(A(x))
-        beta = u.norm()
+        beta = torch.linalg.vector_norm(u)
 
     if beta > 0:
         u.div_(beta)
         v = Armat(u)
-        alpha = v.norm()
+        alpha = torch.linalg.vector_norm(v)
     else:
         v = b.new_zeros(n)
         alpha = b.new_tensor(0, dtype=sdtype)
@@ -268,7 +268,7 @@ def lsmr(
         #        alpha*v  =  A'*u  -  beta*v.
 
         u.mul_(-alpha).add_(A(v))
-        torch.norm(u, out=beta)
+        torch.linalg.vector_norm(u, out=beta)
 
         if (not check_nonzero) or beta > 0:
             # check_nonzero option provides a means to avoid the GPU-CPU
@@ -276,7 +276,7 @@ def lsmr(
             # beta == 0 is unlikely, but use this option with caution.
             u.div_(beta)
             v.mul_(-beta).add_(Armat(u))
-            torch.norm(v, out=alpha)
+            torch.linalg.vector_norm(v, out=alpha)
             v = torch.where(alpha > 0, v / alpha, v)
 
         # At this point, beta = beta_{k+1}, alpha = alpha_{k+1}.
@@ -351,7 +351,7 @@ def lsmr(
         if True:
             # Compute norms for convergence testing.
             torch.abs(zetabar, out=normar)
-            torch.norm(x, out=normx)
+            torch.linalg.vector_norm(x, out=normx)
             torch.div(torch.max(maxrbar, rhotemp), torch.min(minrbar, rhotemp), out=condA)
 
             # Now use these norms to estimate certain other quantities,

--- a/torchsparsegradutils/utils/minres.py
+++ b/torchsparsegradutils/utils/minres.py
@@ -161,7 +161,7 @@ def minres(
         rhs = rhs.unsqueeze(-1)
         squeeze = True
 
-    rhs_norm = rhs.norm(2, dim=-2, keepdim=True)
+    rhs_norm = torch.linalg.vector_norm(rhs, ord=2, dim=-2, keepdim=True)
     rhs_is_zero = rhs_norm.lt(1e-10)
     rhs_norm = rhs_norm.masked_fill_(rhs_is_zero, 1)
     rhs = rhs.div(rhs_norm)
@@ -292,8 +292,8 @@ def minres(
 
         # Check convergence criterion
         if (i + 1) % 10 == 0:
-            torch.norm(search_update, dim=-2, out=search_update_norm)
-            torch.norm(solution, dim=-2, out=solution_norm)
+            torch.linalg.vector_norm(search_update, dim=-2, out=search_update_norm)
+            torch.linalg.vector_norm(solution, dim=-2, out=solution_norm)
             conv = search_update_norm.div_(solution_norm).mean().item()
             if conv < settings.minres_tolerance:
                 break


### PR DESCRIPTION
# Replace deprecated PyTorch APIs

Closes #94.

## Summary

- Replace deprecated `torch.norm` and `Tensor.norm()` calls with `torch.linalg.vector_norm` across library code, tests, benchmarks, and quick-start documentation.
- Replace dense `torch.triangular_solve` references with `torch.linalg.solve_triangular`, preserving transpose behavior by transposing the coefficient matrix and inverting `upper`.
- Remove deprecated `torch.jit.script` decorators from private linear-CG update helpers.
- Add targeted regression checks that prohibit reintroducing explicit `torch.norm` calls, direct triangular-solve calls outside the compatibility module, and `torch.jit.script`.
- Verify that `torch.linalg.solve_triangular` still rejects sparse CSR input and that the compatibility path does not expose PyTorch's deprecation warning.

## Sparse triangular-solve compatibility

PyTorch's documented replacement for `torch.triangular_solve` does not provide the sparse CSR behavior required by `sparse_triangular_solve`. This PR therefore keeps one isolated legacy call in `torchsparsegradutils._compat.sparse_triangular_solve_compat`:

- It preserves existing sparse CSR, COO-to-CSR, batching, transpose, upper/lower, and unit-triangular behavior.
- It suppresses only PyTorch's exact triangular-solve deprecation warning.
- Dense baselines and tests use `torch.linalg.solve_triangular`; no sparse matrix is densified in production code.

## Validation

- `python -m black --check .`
- `python -m isort --check-only --diff .`
- `python -m flake8 . --count --show-source --statistics`
- `python -m pytest -q` — 2,587 passed, 542 skipped
- `python -m build` — source distribution and wheel built successfully
- `python -m sphinx -b html docs/source /tmp/torchsparsegradutils-docs` — succeeded with 11 pre-existing duplicate-citation warnings

`python -m sphinx -W -b html ...` remains blocked by those unrelated, pre-existing citation warnings.

## Scope

- No public API, version, dependency, or release-metadata changes.
- Intentional project-owned encoder deprecations remain unchanged.
