### PR TITLE
chore: prepare v0.2.5 release

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -15,8 +15,8 @@ sys.path.insert(0, os.path.abspath("../../"))
 project = "torchsparsegradutils"
 copyright = "2026, CAI4CAI research group"
 author = "CAI4CAI research group"
-release = "0.2.4"
-version = "0.2.4"
+release = "0.2.5"
+version = "0.2.5"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "torchsparsegradutils"
-version = "0.2.4"
+version = "0.2.5"
 description = "A collection of utility functions to work with PyTorch sparse tensors"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump the package version from 0.2.4 to 0.2.5
- keep the Sphinx `version` and `release` values aligned with package metadata

## Why

This prepares the patch release containing the deprecated PyTorch API replacements merged in PR #95.

## Impact

There are no additional runtime changes in this PR. The resulting source distribution and wheel identify as version 0.2.5.

## Validation

- Black, isort, and flake8
- full test suite: 2,593 passed, 542 skipped
- `python -m build`
- wheel metadata reports `Version: 0.2.5`
- `twine check` passed for the sdist and wheel
