### PR TITLE
ci: automate release preparation

### DIFF
--- a/.codex/skills/torchsparsegradutils-release/SKILL.md
+++ b/.codex/skills/torchsparsegradutils-release/SKILL.md
@@ -65,8 +65,18 @@ docker run --rm torchsparsegradutils-pip-install:<version>
 
 ## Publish Flow
 
-- Merge the PR into `main` before creating the GitHub release.
-- Create the release tag from `main`; the PyPI deployment workflow builds from the release state.
+- Merge functional PRs into `main` before preparing a release.
+- Once the release automation is configured, run the `Prepare release` workflow
+  from `main` with a stable version in `X.Y.Z` form. It updates
+  `pyproject.toml`, `docs/source/conf.py`, and `Dockerfile.pip-install`,
+  validates the distributions, and opens a bot-authored release PR.
+- Require the normal human approval and status checks on the release PR, then
+  squash-merge it. Do not bypass the review step for functional changes.
+- Merging an internal `release/vX.Y.Z` PR creates an unpublished draft GitHub
+  release at that exact merge commit. Review and edit the generated notes before
+  publishing.
+- Publishing the GitHub release creates the tag and triggers the PyPI deployment
+  workflow, which builds from the release state.
 - After publication, verify:
   - PyPI has the new version.
   - `pip install "torchsparsegradutils[all]==<version>"` no longer warns about missing extras.

--- a/.codex/skills/torchsparsegradutils-release/SKILL.md
+++ b/.codex/skills/torchsparsegradutils-release/SKILL.md
@@ -73,10 +73,10 @@ docker run --rm torchsparsegradutils-pip-install:<version>
 - Require the normal human approval and status checks on the release PR, then
   squash-merge it. Do not bypass the review step for functional changes.
 - Merging an internal `release/vX.Y.Z` PR creates an unpublished draft GitHub
-  release at that exact merge commit. Review and edit the generated notes before
-  publishing.
-- Publishing the GitHub release creates the tag and triggers the PyPI deployment
-  workflow, which builds from the release state.
+  release and its associated tag at that exact merge commit. Review and edit the
+  generated notes before publishing.
+- Publishing the GitHub release triggers the PyPI deployment workflow, which
+  builds from the release state.
 - After publication, verify:
   - PyPI has the new version.
   - `pip install "torchsparsegradutils[all]==<version>"` no longer warns about missing extras.

--- a/.github/scripts/update_release_version.py
+++ b/.github/scripts/update_release_version.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Validate or update every repository location containing the release version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+STABLE_VERSION = re.compile(r"(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)")
+
+
+class ReleaseVersionError(ValueError):
+    """Raised when release version metadata is invalid or inconsistent."""
+
+
+@dataclass(frozen=True)
+class VersionFiles:
+    pyproject: Path
+    sphinx_conf: Path
+    pip_install_dockerfile: Path
+
+    @classmethod
+    def from_root(cls, root: Path) -> "VersionFiles":
+        return cls(
+            pyproject=root / "pyproject.toml",
+            sphinx_conf=root / "docs" / "source" / "conf.py",
+            pip_install_dockerfile=root / "Dockerfile.pip-install",
+        )
+
+
+def parse_stable_version(value: str) -> tuple[int, int, int]:
+    match = STABLE_VERSION.fullmatch(value)
+    if match is None:
+        raise ReleaseVersionError(
+            f"Expected a stable release version in X.Y.Z form without a leading 'v'; got {value!r}"
+        )
+    return tuple(int(part) for part in match.groups())
+
+
+def _single_match(pattern: str, text: str, path: Path, description: str) -> str:
+    matches = re.findall(pattern, text, flags=re.MULTILINE)
+    if len(matches) != 1:
+        raise ReleaseVersionError(f"Expected exactly one {description} in {path}, found {len(matches)}")
+    return matches[0]
+
+
+def read_versions(files: VersionFiles) -> dict[str, str]:
+    pyproject_text = files.pyproject.read_text(encoding="utf-8")
+    sphinx_text = files.sphinx_conf.read_text(encoding="utf-8")
+    dockerfile_text = files.pip_install_dockerfile.read_text(encoding="utf-8")
+
+    project_section = _single_match(
+        r"^\[project\]\s*$([\s\S]*?)(?=^\[|\Z)",
+        pyproject_text,
+        files.pyproject,
+        "[project] section",
+    )
+    package_version = _single_match(
+        r'^version\s*=\s*"([^"]+)"\s*$',
+        project_section,
+        files.pyproject,
+        "project.version value",
+    )
+
+    return {
+        "pyproject.toml project.version": package_version,
+        "docs/source/conf.py release": _single_match(
+            r'^release\s*=\s*"([^"]+)"\s*$',
+            sphinx_text,
+            files.sphinx_conf,
+            "Sphinx release value",
+        ),
+        "docs/source/conf.py version": _single_match(
+            r'^version\s*=\s*"([^"]+)"\s*$',
+            sphinx_text,
+            files.sphinx_conf,
+            "Sphinx version value",
+        ),
+        "Dockerfile.pip-install PACKAGE_SPEC": _single_match(
+            r"^ARG PACKAGE_SPEC=torchsparsegradutils\[all\]==([^\s]+)\s*$",
+            dockerfile_text,
+            files.pip_install_dockerfile,
+            "PACKAGE_SPEC version",
+        ),
+        "Dockerfile.pip-install installed-version assertion": _single_match(
+            r'^assert dist\.version == "([^"]+)", dist\.version\s*$',
+            dockerfile_text,
+            files.pip_install_dockerfile,
+            "installed distribution version assertion",
+        ),
+    }
+
+
+def validate_versions(files: VersionFiles, expected: str | None = None) -> str:
+    versions = read_versions(files)
+    unique_versions = set(versions.values())
+    if len(unique_versions) != 1:
+        details = "\n".join(f"- {location}: {version}" for location, version in versions.items())
+        raise ReleaseVersionError(f"Release version metadata is inconsistent:\n{details}")
+
+    current = unique_versions.pop()
+    parse_stable_version(current)
+    if expected is not None and current != expected:
+        raise ReleaseVersionError(f"Expected all release metadata to be {expected}, found {current}")
+    return current
+
+
+def _replace_once(text: str, old: str, new: str, path: Path, description: str) -> str:
+    count = text.count(old)
+    if count != 1:
+        raise ReleaseVersionError(f"Expected exactly one {description} in {path}, found {count}")
+    return text.replace(old, new, 1)
+
+
+def update_versions(files: VersionFiles, new_version: str) -> str:
+    new_tuple = parse_stable_version(new_version)
+    current = validate_versions(files)
+    if new_tuple <= parse_stable_version(current):
+        raise ReleaseVersionError(f"New version {new_version} must be greater than current version {current}")
+
+    pyproject_text = _replace_once(
+        files.pyproject.read_text(encoding="utf-8"),
+        f'version = "{current}"',
+        f'version = "{new_version}"',
+        files.pyproject,
+        "project version",
+    )
+    sphinx_text = files.sphinx_conf.read_text(encoding="utf-8")
+    sphinx_text = _replace_once(
+        sphinx_text,
+        f'release = "{current}"',
+        f'release = "{new_version}"',
+        files.sphinx_conf,
+        "Sphinx release value",
+    )
+    sphinx_text = _replace_once(
+        sphinx_text,
+        f'version = "{current}"',
+        f'version = "{new_version}"',
+        files.sphinx_conf,
+        "Sphinx version value",
+    )
+    dockerfile_text = files.pip_install_dockerfile.read_text(encoding="utf-8")
+    dockerfile_text = _replace_once(
+        dockerfile_text,
+        f"ARG PACKAGE_SPEC=torchsparsegradutils[all]=={current}",
+        f"ARG PACKAGE_SPEC=torchsparsegradutils[all]=={new_version}",
+        files.pip_install_dockerfile,
+        "PACKAGE_SPEC version",
+    )
+    dockerfile_text = _replace_once(
+        dockerfile_text,
+        f'assert dist.version == "{current}", dist.version',
+        f'assert dist.version == "{new_version}", dist.version',
+        files.pip_install_dockerfile,
+        "installed distribution version assertion",
+    )
+
+    files.pyproject.write_text(pyproject_text, encoding="utf-8")
+    files.sphinx_conf.write_text(sphinx_text, encoding="utf-8")
+    files.pip_install_dockerfile.write_text(dockerfile_text, encoding="utf-8")
+    validate_versions(files, expected=new_version)
+    return current
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("version", help="Stable release version in X.Y.Z form, without a leading 'v'")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate that every version location already matches VERSION without changing files",
+    )
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path.cwd(),
+        help=argparse.SUPPRESS,
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    files = VersionFiles.from_root(args.root.resolve())
+
+    try:
+        parse_stable_version(args.version)
+        if args.check:
+            validate_versions(files, expected=args.version)
+            print(f"Release version metadata is consistent at {args.version}")
+        else:
+            previous = update_versions(files, args.version)
+            print(f"Updated release version metadata from {previous} to {args.version}")
+    except (OSError, ReleaseVersionError) as error:
+        parser.error(str(error))
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -77,13 +77,27 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TAG: ${{ steps.release.outputs.tag }}
         run: |
+          existing_release="$(
+            gh release view "${TAG}" --repo "${REPOSITORY}" \
+              --json isDraft,targetCommitish \
+              --jq '[.isDraft, .targetCommitish] | @tsv' 2>/dev/null || true
+          )"
+          if [[ -n "${existing_release}" ]]; then
+            IFS=$'\t' read -r existing_is_draft existing_target <<< "${existing_release}"
+            if [[ "${existing_is_draft}" != "true" ]]; then
+              echo "Release ${TAG} already exists and is not a draft." >&2
+              exit 1
+            fi
+            if [[ "${existing_target}" != "${MERGE_SHA}" ]]; then
+              echo "Draft release ${TAG} targets ${existing_target}, not ${MERGE_SHA}." >&2
+              exit 1
+            fi
+            echo "Draft release ${TAG} already exists at ${MERGE_SHA}; leaving it unchanged."
+            exit 0
+          fi
           if git rev-parse --quiet --verify "refs/tags/${TAG}" >/dev/null; then
             echo "Refusing to create a draft because tag ${TAG} already exists." >&2
             exit 1
-          fi
-          if gh release view "${TAG}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
-            echo "Release ${TAG} already exists; leaving it unchanged."
-            exit 0
           fi
           gh release create "${TAG}" --repo "${REPOSITORY}" --draft --generate-notes --target "${MERGE_SHA}" --title "${TAG}"
 

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -1,0 +1,104 @@
+name: Draft GitHub release
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: draft-release-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  draft-release:
+    name: Create draft release
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      startsWith(github.event.pull_request.head.ref, 'release/v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: read
+
+      - name: Check out the merge commit
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify release-only scope
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          expected_files=$'Dockerfile.pip-install\ndocs/source/conf.py\npyproject.toml'
+          actual_files="$(gh api "repos/${REPOSITORY}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' | LC_ALL=C sort)"
+          if [[ "${actual_files}" != "${expected_files}" ]]; then
+            echo "Refusing to draft a release for a PR with unexpected files:" >&2
+            echo "${actual_files}" >&2
+            exit 1
+          fi
+
+      - name: Verify merged version metadata
+        id: release
+        env:
+          HEAD_BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: |
+          version="${HEAD_BRANCH#release/v}"
+          python .github/scripts/update_release_version.py "${version}" --check
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Create unpublished draft release
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          if git rev-parse --quiet --verify "refs/tags/${TAG}" >/dev/null; then
+            echo "Refusing to create a draft because tag ${TAG} already exists." >&2
+            exit 1
+          fi
+          if gh release view "${TAG}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release ${TAG} already exists; leaving it unchanged."
+            exit 0
+          fi
+          gh release create "${TAG}" --repo "${REPOSITORY}" --draft --generate-notes --target "${MERGE_SHA}" --title "${TAG}"
+
+      - name: Summarize next step
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          REPOSITORY: ${{ github.repository }}
+          TAG: ${{ steps.release.outputs.tag }}
+        run: |
+          release_url="$(gh release view "${TAG}" --repo "${REPOSITORY}" --json url --jq .url)"
+          {
+            echo "## Draft release created"
+            echo
+            echo "Review and edit the generated notes before publishing:"
+            echo "${release_url}"
+            echo
+            echo "Publishing triggers the existing PyPI deployment workflow."
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,0 +1,139 @@
+name: Prepare release
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: Stable release version without a leading v (for example, 0.2.6)
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: prepare-release
+  cancel-in-progress: false
+
+jobs:
+  release-pr:
+    name: Create release PR
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Create release-bot token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
+      - name: Check out the default branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.repository.default_branch }}
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Verify the workflow is running from the default branch
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          if [[ "${GITHUB_REF_NAME}" != "${DEFAULT_BRANCH}" ]]; then
+            echo "Run this workflow from ${DEFAULT_BRANCH}, not ${GITHUB_REF_NAME}." >&2
+            exit 1
+          fi
+
+      - name: Update and verify release metadata
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          RELEASE_VERSION: ${{ inputs.version }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          python .github/scripts/update_release_version.py "${RELEASE_VERSION}"
+          python .github/scripts/update_release_version.py "${RELEASE_VERSION}" --check
+          if git rev-parse --quiet --verify "refs/tags/v${RELEASE_VERSION}" >/dev/null; then
+            echo "Tag v${RELEASE_VERSION} already exists." >&2
+            exit 1
+          fi
+          if gh release view "v${RELEASE_VERSION}" --repo "${REPOSITORY}" >/dev/null 2>&1; then
+            echo "Release v${RELEASE_VERSION} already exists." >&2
+            exit 1
+          fi
+
+      - name: Build and check distributions
+        run: |
+          python -m pip install --upgrade build twine
+          python -m build
+          python -m twine check dist/*
+
+      - name: Resolve release-bot identity
+        id: bot
+        env:
+          APP_SLUG: ${{ steps.app-token.outputs.app-slug }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          bot_login="${APP_SLUG}[bot]"
+          bot_id="$(gh api "/users/${bot_login}" --jq .id)"
+          echo "name=${bot_login}" >> "${GITHUB_OUTPUT}"
+          echo "email=${bot_id}+${bot_login}@users.noreply.github.com" >> "${GITHUB_OUTPUT}"
+
+      - name: Create release pull request
+        id: release-pr
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          add-paths: |
+            Dockerfile.pip-install
+            docs/source/conf.py
+            pyproject.toml
+          branch: release/v${{ inputs.version }}
+          base: ${{ github.event.repository.default_branch }}
+          delete-branch: true
+          commit-message: "chore: prepare v${{ inputs.version }} release"
+          title: "chore: prepare v${{ inputs.version }} release"
+          committer: "${{ steps.bot.outputs.name }} <${{ steps.bot.outputs.email }}>"
+          author: "${{ steps.bot.outputs.name }} <${{ steps.bot.outputs.email }}>"
+          sign-commits: true
+          reviewers: ${{ github.actor }}
+          body: |
+            ## Summary
+
+            - bump the package version to `${{ inputs.version }}`
+            - keep Sphinx and installed-wheel validation metadata aligned
+
+            ## Why
+
+            This bot-authored PR prepares the next release after the functional
+            changes have already been reviewed and merged.
+
+            ## Human review checklist
+
+            - [ ] Confirm the intended release version is `${{ inputs.version }}`.
+            - [ ] Confirm the diff contains only `pyproject.toml`,
+                  `docs/source/conf.py`, and `Dockerfile.pip-install`.
+            - [ ] Confirm all required CI checks pass.
+            - [ ] Approve and squash-merge this PR.
+
+            After merge, the release workflow will create an unpublished draft
+            GitHub release. Review and edit its generated notes before publishing;
+            publishing the release triggers the existing PyPI deployment.
+
+      - name: Summarize result
+        env:
+          OPERATION: ${{ steps.release-pr.outputs.pull-request-operation }}
+          PR_URL: ${{ steps.release-pr.outputs.pull-request-url }}
+        run: |
+          {
+            echo "## Release PR"
+            echo
+            echo "Operation: ${OPERATION}"
+            echo "Pull request: ${PR_URL}"
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/torchsparsegradutils/tests/test_release_version.py
+++ b/torchsparsegradutils/tests/test_release_version.py
@@ -1,0 +1,94 @@
+"""Tests for the repository release-version update helper."""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPOSITORY_ROOT = Path(__file__).parents[2]
+UPDATE_SCRIPT = REPOSITORY_ROOT / ".github" / "scripts" / "update_release_version.py"
+pytestmark = pytest.mark.skipif(
+    not UPDATE_SCRIPT.is_file(),
+    reason="release updater is repository automation and is not included in installed wheels",
+)
+
+
+def write_version_files(root, version="0.2.5"):
+    (root / "docs" / "source").mkdir(parents=True)
+    (root / "pyproject.toml").write_text(
+        f'[project]\nname = "example"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    (root / "docs" / "source" / "conf.py").write_text(
+        f'release = "{version}"\nversion = "{version}"\n',
+        encoding="utf-8",
+    )
+    (root / "Dockerfile.pip-install").write_text(
+        "FROM python:3.12-slim\n"
+        f"ARG PACKAGE_SPEC=torchsparsegradutils[all]=={version}\n"
+        "RUN python - <<'PY'\n"
+        f'assert dist.version == "{version}", dist.version\n'
+        "PY\n",
+        encoding="utf-8",
+    )
+
+
+def run_updater(root, version, *extra_args):
+    return subprocess.run(
+        [sys.executable, str(UPDATE_SCRIPT), version, *extra_args, "--root", str(root)],
+        capture_output=True,
+        check=False,
+        text=True,
+    )
+
+
+def test_update_release_version_updates_every_location(tmp_path):
+    write_version_files(tmp_path)
+
+    result = run_updater(tmp_path, "0.2.6")
+
+    assert result.returncode == 0, result.stderr
+    for path in (
+        tmp_path / "pyproject.toml",
+        tmp_path / "docs" / "source" / "conf.py",
+        tmp_path / "Dockerfile.pip-install",
+    ):
+        contents = path.read_text(encoding="utf-8")
+        assert "0.2.5" not in contents
+        assert "0.2.6" in contents
+
+    check_result = run_updater(tmp_path, "0.2.6", "--check")
+    assert check_result.returncode == 0, check_result.stderr
+
+
+def test_update_release_version_rejects_inconsistent_metadata(tmp_path):
+    write_version_files(tmp_path)
+    conf_path = tmp_path / "docs" / "source" / "conf.py"
+    conf_path.write_text(
+        conf_path.read_text(encoding="utf-8").replace('version = "0.2.5"', 'version = "0.2.4"'),
+        encoding="utf-8",
+    )
+
+    result = run_updater(tmp_path, "0.2.6")
+
+    assert result.returncode != 0
+    assert "Release version metadata is inconsistent" in result.stderr
+
+
+def test_update_release_version_rejects_non_increasing_version(tmp_path):
+    write_version_files(tmp_path)
+
+    result = run_updater(tmp_path, "0.2.5")
+
+    assert result.returncode != 0
+    assert "must be greater than current version" in result.stderr
+
+
+def test_update_release_version_rejects_invalid_stable_version(tmp_path):
+    write_version_files(tmp_path)
+
+    result = run_updater(tmp_path, "v0.2.6")
+
+    assert result.returncode != 0
+    assert "without a leading 'v'" in result.stderr


### PR DESCRIPTION
## Summary

- add a manually dispatched workflow that validates a stable release version, updates all maintained version locations, builds the distributions, and opens a bot-authored release PR
- add a merge-triggered workflow that verifies release-only scope and version consistency before creating an unpublished draft GitHub release
- add a shared release-version updater with tests for successful updates and invalid or inconsistent metadata
- document the guarded release flow in the repository release skill

## Safety model

- release preparation can run only from the default branch
- the generated release PR is limited to `pyproject.toml`, `docs/source/conf.py`, and `Dockerfile.pip-install`
- normal human review and required CI remain mandatory
- draft creation accepts only merged, repository-local `release/v*` PRs with exactly those three files
- release publication remains a separate human action; only publication triggers the existing PyPI deployment
- GitHub Actions are pinned to immutable commit SHAs and the release App requests only the required repository permissions

## Validation

- `python -m black --check .`
- `python -m isort --check-only --diff .`
- `python -m flake8 . --count --show-source --statistics`
- `python -m pytest -q` — 2,597 passed, 542 skipped
- `python -m build`
- pre-commit hooks passed during commit

## Follow-up

The organization-owner setup and acceptance check are tracked in #98. The new workflows cannot be used until the GitHub App credentials described there are configured.

