### PR TITLE
Fix linear CG convergence and diagnostics

### DIFF
--- a/torchsparsegradutils/benchmarks/linear_cg_convergence.py
+++ b/torchsparsegradutils/benchmarks/linear_cg_convergence.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Compare linear-CG convergence before and after the diagnostics fix.
+
+This benchmark focuses on numerical behavior rather than throughput. It loads
+the historical implementation from Git so both solvers run in one Python
+environment on identical deterministic inputs.
+
+Example
+-------
+python -m torchsparsegradutils.benchmarks.linear_cg_convergence \
+    --baseline-ref a4fab0b --repeats 100
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+import types
+import warnings
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+import torch
+
+from torchsparsegradutils.utils import linear_cg
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
+LINEAR_CG_PATH = "torchsparsegradutils/utils/linear_cg.py"
+
+
+@dataclass(frozen=True)
+class Problem:
+    name: str
+    matrix: torch.Tensor
+    rhs: torch.Tensor
+    tolerance: float
+    max_iter: int
+    initial_guess: torch.Tensor | None = None
+
+
+class CountedMatmul:
+    def __init__(self, matrix: torch.Tensor):
+        self.matrix = matrix
+        self.calls = 0
+
+    def __call__(self, value: torch.Tensor) -> torch.Tensor:
+        self.calls += 1
+        return self.matrix @ value
+
+
+def load_historical_linear_cg(revision: str) -> Callable[..., torch.Tensor]:
+    """Load ``linear_cg`` from a Git revision without changing the worktree."""
+    completed = subprocess.run(
+        ["git", "-C", str(REPOSITORY_ROOT), "show", f"{revision}:{LINEAR_CG_PATH}"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    module = types.ModuleType("historical_linear_cg")
+    exec(compile(completed.stdout, f"{revision}:{LINEAR_CG_PATH}", "exec"), module.__dict__)
+    return module.linear_cg
+
+
+def make_problems(device: torch.device) -> list[Problem]:
+    dtype = torch.float64
+
+    size = 36
+    diagonal = torch.full((size,), 2.0, dtype=dtype, device=device)
+    off_diagonal = torch.full((size - 1,), -0.25, dtype=dtype, device=device)
+    tight_matrix = torch.diag(diagonal) + torch.diag(off_diagonal, diagonal=1) + torch.diag(off_diagonal, diagonal=-1)
+    tight_rhs = torch.zeros(size, dtype=dtype, device=device)
+    tight_rhs[size // 2] = 1
+
+    size = 40
+    multiple_matrix = torch.diag(torch.linspace(1.0, 100.0, size, dtype=dtype, device=device))
+    multiple_rhs = torch.zeros((size, 101), dtype=dtype, device=device)
+    multiple_rhs[:, -1] = 1
+
+    zero_matrix = torch.diag(torch.tensor([1.0, 2.0, 3.0], dtype=dtype, device=device))
+    zero_rhs = torch.zeros(3, dtype=dtype, device=device)
+
+    return [
+        Problem("tight_tolerance", tight_matrix, tight_rhs, tolerance=1e-12, max_iter=200),
+        Problem("multiple_rhs", multiple_matrix, multiple_rhs, tolerance=1e-4, max_iter=size),
+        Problem(
+            "zero_rhs_nonzero_guess",
+            zero_matrix,
+            zero_rhs,
+            tolerance=1e-5,
+            max_iter=20,
+            initial_guess=torch.ones_like(zero_rhs),
+        ),
+    ]
+
+
+def synchronize(device: torch.device) -> None:
+    if device.type == "cuda":
+        torch.cuda.synchronize(device)
+
+
+def relative_residual_per_rhs(matrix: torch.Tensor, solution: torch.Tensor, rhs: torch.Tensor) -> torch.Tensor:
+    if rhs.ndim == 1:
+        rhs = rhs.unsqueeze(-1)
+        solution = solution.unsqueeze(-1)
+    residual_norm = torch.linalg.vector_norm(rhs - matrix @ solution, dim=-2)
+    rhs_norm = torch.linalg.vector_norm(rhs, dim=-2)
+    return residual_norm / rhs_norm.masked_fill(rhs_norm.eq(0), 1)
+
+
+def run_once(
+    solver: Callable[..., torch.Tensor],
+    problem: Problem,
+    *,
+    fixed: bool,
+) -> tuple[torch.Tensor, int, int, str]:
+    matmul = CountedMatmul(problem.matrix)
+    arguments = {
+        "tolerance": problem.tolerance,
+        "max_iter": problem.max_iter,
+        "initial_guess": problem.initial_guess,
+    }
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", UserWarning)
+        if fixed:
+            solution, info = solver(matmul, problem.rhs, return_info=True, **arguments)
+            return solution, info.iterations, matmul.calls, info.reason
+        solution = solver(matmul, problem.rhs, **arguments)
+    # The historical solver performs one initial matvec followed by one per
+    # iteration and does not recompute the true residual before returning.
+    return solution, max(0, matmul.calls - 1), matmul.calls, "not_reported"
+
+
+def measure(
+    solver: Callable[..., torch.Tensor],
+    problem: Problem,
+    *,
+    fixed: bool,
+    warmup: int,
+    repeats: int,
+) -> dict[str, object]:
+    for _ in range(warmup):
+        run_once(solver, problem, fixed=fixed)
+    synchronize(problem.rhs.device)
+
+    durations = []
+    for _ in range(repeats):
+        start = time.perf_counter()
+        run_once(solver, problem, fixed=fixed)
+        synchronize(problem.rhs.device)
+        durations.append(time.perf_counter() - start)
+
+    solution, iterations, matvecs, reason = run_once(solver, problem, fixed=fixed)
+    true_residual = relative_residual_per_rhs(problem.matrix, solution, problem.rhs)
+    reference = torch.linalg.solve(problem.matrix, problem.rhs)
+    error = torch.linalg.vector_norm(solution - reference) / torch.linalg.vector_norm(reference).clamp_min(1)
+
+    return {
+        "iterations": iterations,
+        "matvecs": matvecs,
+        "reason": reason,
+        "true_relative_residual_max": float(true_residual.max()),
+        "unconverged_rhs": int((true_residual > problem.tolerance).sum()),
+        "relative_solution_error": float(error),
+        "median_time_ms": statistics.median(durations) * 1e3,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--baseline-ref", default="a4fab0b", help="Git revision containing the historical solver")
+    parser.add_argument("--device", default="cpu", help="PyTorch device (default: cpu)")
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=50)
+    arguments = parser.parse_args()
+    if arguments.warmup < 0 or arguments.repeats < 1:
+        parser.error("--warmup must be nonnegative and --repeats must be positive")
+    return arguments
+
+
+def main() -> None:
+    arguments = parse_args()
+    device = torch.device(arguments.device)
+    historical_linear_cg = load_historical_linear_cg(arguments.baseline_ref)
+    results = {}
+    for problem in make_problems(device):
+        results[problem.name] = {
+            "baseline": measure(
+                historical_linear_cg,
+                problem,
+                fixed=False,
+                warmup=arguments.warmup,
+                repeats=arguments.repeats,
+            ),
+            "fixed": measure(
+                linear_cg,
+                problem,
+                fixed=True,
+                warmup=arguments.warmup,
+                repeats=arguments.repeats,
+            ),
+        }
+
+    payload = {
+        "baseline_ref": arguments.baseline_ref,
+        "device": str(device),
+        "torch_version": torch.__version__,
+        "warmup": arguments.warmup,
+        "repeats": arguments.repeats,
+        "results": results,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/torchsparsegradutils/benchmarks/linear_cg_convergence.py
+++ b/torchsparsegradutils/benchmarks/linear_cg_convergence.py
@@ -54,12 +54,17 @@ class CountedMatmul:
 
 def load_historical_linear_cg(revision: str) -> Callable[..., torch.Tensor]:
     """Load ``linear_cg`` from a Git revision without changing the worktree."""
-    completed = subprocess.run(
-        ["git", "-C", str(REPOSITORY_ROOT), "show", f"{revision}:{LINEAR_CG_PATH}"],
-        check=True,
-        capture_output=True,
-        text=True,
-    )
+    command = ["git", "-C", str(REPOSITORY_ROOT), "show", f"{revision}:{LINEAR_CG_PATH}"]
+    try:
+        completed = subprocess.run(command, check=True, capture_output=True, text=True)
+    except FileNotFoundError as error:
+        raise RuntimeError("Cannot load the historical solver because the Git executable was not found") from error
+    except subprocess.CalledProcessError as error:
+        detail = error.stderr.strip() or "Git could not resolve the requested revision and file"
+        raise RuntimeError(
+            f"Cannot load the historical solver from revision {revision!r}. "
+            f"Run this benchmark from a Git checkout containing that revision. Git reported: {detail}"
+        ) from error
     module = types.ModuleType("historical_linear_cg")
     exec(compile(completed.stdout, f"{revision}:{LINEAR_CG_PATH}", "exec"), module.__dict__)
     return module.linear_cg

--- a/torchsparsegradutils/benchmarks/linear_cg_convergence.py
+++ b/torchsparsegradutils/benchmarks/linear_cg_convergence.py
@@ -8,7 +8,7 @@ environment on identical deterministic inputs.
 Example
 -------
 python -m torchsparsegradutils.benchmarks.linear_cg_convergence \
-    --baseline-ref a4fab0b --repeats 100
+    --baseline-ref ea7b8f0 --repeats 100
 """
 
 from __future__ import annotations
@@ -176,7 +176,7 @@ def measure(
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--baseline-ref", default="a4fab0b", help="Git revision containing the historical solver")
+    parser.add_argument("--baseline-ref", default="ea7b8f0", help="Git revision containing the historical solver")
     parser.add_argument("--device", default="cpu", help="PyTorch device (default: cpu)")
     parser.add_argument("--warmup", type=int, default=5)
     parser.add_argument("--repeats", type=int, default=50)

--- a/torchsparsegradutils/sparse_solve.py
+++ b/torchsparsegradutils/sparse_solve.py
@@ -235,20 +235,9 @@ class SparseTriangularSolve(torch.autograd.Function):
         gradA = torch.sum(mgbx, dim=1)
 
         if ctx.csr is False:
-            gradA = torch.sparse_coo_tensor(
-                torch.stack([A_row_idx, A_col_idx]),
-                gradA,
-                A.shape,
-                check_invariants=True,
-            )
+            gradA = torch.sparse_coo_tensor(torch.stack([A_row_idx, A_col_idx]), gradA, A.shape)
         else:
-            gradA = torch.sparse_csr_tensor(
-                A_crow_idx,
-                A_col_idx,
-                gradA,
-                A.shape,
-                check_invariants=True,
-            )
+            gradA = torch.sparse_csr_tensor(A_crow_idx, A_col_idx, gradA, A.shape)
 
         if ctx.batch_size is not None:
             shapes = ctx.A_shape[0] * (ctx.A_shape[-2:],)
@@ -519,20 +508,9 @@ class SparseGenericSolve(torch.autograd.Function):
             gradA = gradA.to(dtype=A.dtype)
 
         if A.layout == torch.sparse_coo:
-            gradA = torch.sparse_coo_tensor(
-                torch.stack([A_row_idx, A_col_idx]),
-                gradA,
-                A.shape,
-                check_invariants=True,
-            )
+            gradA = torch.sparse_coo_tensor(torch.stack([A_row_idx, A_col_idx]), gradA, A.shape)
         else:
-            gradA = torch.sparse_csr_tensor(
-                A.crow_indices(),
-                A_col_idx,
-                gradA,
-                A.shape,
-                check_invariants=True,
-            )
+            gradA = torch.sparse_csr_tensor(A.crow_indices(), A_col_idx, gradA, A.shape)
 
         # Squeeze gradB back to original shape if it was a vector
         if is_vector:

--- a/torchsparsegradutils/sparse_solve.py
+++ b/torchsparsegradutils/sparse_solve.py
@@ -235,9 +235,20 @@ class SparseTriangularSolve(torch.autograd.Function):
         gradA = torch.sum(mgbx, dim=1)
 
         if ctx.csr is False:
-            gradA = torch.sparse_coo_tensor(torch.stack([A_row_idx, A_col_idx]), gradA, A.shape)
+            gradA = torch.sparse_coo_tensor(
+                torch.stack([A_row_idx, A_col_idx]),
+                gradA,
+                A.shape,
+                check_invariants=True,
+            )
         else:
-            gradA = torch.sparse_csr_tensor(A_crow_idx, A_col_idx, gradA, A.shape)
+            gradA = torch.sparse_csr_tensor(
+                A_crow_idx,
+                A_col_idx,
+                gradA,
+                A.shape,
+                check_invariants=True,
+            )
 
         if ctx.batch_size is not None:
             shapes = ctx.A_shape[0] * (ctx.A_shape[-2:],)
@@ -508,9 +519,20 @@ class SparseGenericSolve(torch.autograd.Function):
             gradA = gradA.to(dtype=A.dtype)
 
         if A.layout == torch.sparse_coo:
-            gradA = torch.sparse_coo_tensor(torch.stack([A_row_idx, A_col_idx]), gradA, A.shape)
+            gradA = torch.sparse_coo_tensor(
+                torch.stack([A_row_idx, A_col_idx]),
+                gradA,
+                A.shape,
+                check_invariants=True,
+            )
         else:
-            gradA = torch.sparse_csr_tensor(A.crow_indices(), A_col_idx, gradA, A.shape)
+            gradA = torch.sparse_csr_tensor(
+                A.crow_indices(),
+                A_col_idx,
+                gradA,
+                A.shape,
+                check_invariants=True,
+            )
 
         # Squeeze gradB back to original shape if it was a vector
         if is_vector:

--- a/torchsparsegradutils/tests/test_linear_cg.py
+++ b/torchsparsegradutils/tests/test_linear_cg.py
@@ -178,3 +178,17 @@ def test_vector_rank_is_preserved_with_vector_initial_guess():
 
     with pytest.raises(ValueError, match="initial_guess must have shape"):
         linear_cg(matrix, rhs, initial_guess=torch.zeros((3, 2), dtype=torch.float64))
+
+
+def test_multiple_batch_dimensions_are_supported():
+    with pytest.raises(ValueError, match="at least one dimension"):
+        linear_cg(torch.ones((1, 1), dtype=torch.float64), torch.tensor(1.0, dtype=torch.float64))
+
+    matrix = torch.diag(torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+    rhs = torch.ones((2, 4, 3, 2), dtype=torch.float64)
+
+    solution = linear_cg(matrix, rhs, tolerance=1e-12)
+    expected = torch.linalg.solve(matrix, rhs)
+
+    assert solution.shape == rhs.shape
+    torch.testing.assert_close(solution, expected, rtol=1e-12, atol=1e-12)

--- a/torchsparsegradutils/tests/test_linear_cg.py
+++ b/torchsparsegradutils/tests/test_linear_cg.py
@@ -102,3 +102,79 @@ def test_batch_cg_init():
     chol = torch.linalg.cholesky(matrix)
     actual = torch.cholesky_solve(rhs, chol)
     assert torch.allclose(solves_init, actual, atol=1e-3, rtol=1e-4)
+
+
+def test_tight_tolerance_does_not_stall_at_historical_absolute_epsilon():
+    size = 36
+    diagonal = torch.full((size,), 2.0, dtype=torch.float64)
+    off_diagonal = torch.full((size - 1,), -0.25, dtype=torch.float64)
+    matrix = torch.diag(diagonal) + torch.diag(off_diagonal, 1) + torch.diag(off_diagonal, -1)
+    rhs = torch.zeros(size, dtype=torch.float64)
+    rhs[size // 2] = 1
+
+    solution, info = linear_cg(matrix, rhs, tolerance=1e-12, max_iter=200, return_info=True)
+    expected = torch.linalg.solve(matrix, rhs)
+
+    torch.testing.assert_close(solution, expected, rtol=1e-10, atol=1e-12)
+    assert info.reason == "converged"
+    assert info.converged.all()
+    assert info.true_relative_residual.max() <= 1e-12
+    assert info.iterations <= size
+
+
+def test_all_rhs_convergence_does_not_hide_one_hard_column():
+    size = 40
+    matrix = torch.diag(torch.linspace(1.0, 100.0, size, dtype=torch.float64))
+    rhs = torch.zeros((size, 101), dtype=torch.float64)
+    rhs[:, -1] = 1
+
+    with pytest.warns(UserWarning):
+        _, mean_info = linear_cg(
+            matrix,
+            rhs,
+            tolerance=1e-4,
+            max_iter=size,
+            convergence_reduction="mean",
+            return_info=True,
+        )
+    all_solution, all_info = linear_cg(
+        matrix,
+        rhs,
+        tolerance=1e-4,
+        max_iter=size,
+        convergence_reduction="all",
+        return_info=True,
+    )
+
+    assert mean_info.reason == "mean_converged"
+    assert not mean_info.converged[..., -1].all()
+    assert all_info.reason == "converged"
+    assert all_info.converged.all()
+    assert all_info.true_relative_residual.max() <= 1e-4
+    torch.testing.assert_close(all_solution, torch.linalg.solve(matrix, rhs), rtol=2e-4, atol=1e-6)
+
+
+def test_zero_rhs_returns_zero_even_with_nonzero_initial_guess():
+    matrix = torch.diag(torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+    rhs = torch.zeros(3, dtype=torch.float64)
+    initial_guess = torch.ones(3, dtype=torch.float64)
+
+    solution, info = linear_cg(matrix, rhs, initial_guess=initial_guess, return_info=True)
+
+    torch.testing.assert_close(solution, torch.zeros_like(rhs), rtol=0, atol=0)
+    assert info.iterations == 0
+    assert info.converged.all()
+    assert info.true_relative_residual.max() == 0
+
+
+def test_vector_rank_is_preserved_with_vector_initial_guess():
+    matrix = torch.diag(torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+    rhs = torch.ones(3, dtype=torch.float64)
+    solution = linear_cg(matrix, rhs, initial_guess=torch.zeros_like(rhs))
+    assert solution.shape == rhs.shape
+
+    column_guess_solution = linear_cg(matrix, rhs, initial_guess=torch.zeros((3, 1), dtype=torch.float64))
+    assert column_guess_solution.shape == rhs.shape
+
+    with pytest.raises(ValueError, match="initial_guess must have shape"):
+        linear_cg(matrix, rhs, initial_guess=torch.zeros((3, 2), dtype=torch.float64))

--- a/torchsparsegradutils/tests/test_linear_cg.py
+++ b/torchsparsegradutils/tests/test_linear_cg.py
@@ -180,6 +180,27 @@ def test_vector_rank_is_preserved_with_vector_initial_guess():
         linear_cg(matrix, rhs, initial_guess=torch.zeros((3, 2), dtype=torch.float64))
 
 
+def test_min_iter_is_honored_for_converged_initial_guess():
+    matrix = torch.eye(3, dtype=torch.float64)
+    rhs = torch.ones(3, dtype=torch.float64)
+
+    solution, info = linear_cg(
+        matrix,
+        rhs,
+        initial_guess=rhs,
+        min_iter=3,
+        max_iter=5,
+        max_tridiag_iter=0,
+        return_info=True,
+    )
+
+    torch.testing.assert_close(solution, rhs, rtol=0, atol=0)
+    assert info.iterations == 3
+    assert info.matvecs == 5
+    assert info.reason == "converged"
+    assert info.converged.all()
+
+
 def test_multiple_batch_dimensions_are_supported():
     with pytest.raises(ValueError, match="at least one dimension"):
         linear_cg(torch.ones((1, 1), dtype=torch.float64), torch.tensor(1.0, dtype=torch.float64))

--- a/torchsparsegradutils/tests/test_linear_cg.py
+++ b/torchsparsegradutils/tests/test_linear_cg.py
@@ -159,12 +159,163 @@ def test_zero_rhs_returns_zero_even_with_nonzero_initial_guess():
     rhs = torch.zeros(3, dtype=torch.float64)
     initial_guess = torch.ones(3, dtype=torch.float64)
 
-    solution, info = linear_cg(matrix, rhs, initial_guess=initial_guess, return_info=True)
+    solution, info = linear_cg(matrix, rhs, initial_guess=initial_guess, tolerance=0, return_info=True)
 
     torch.testing.assert_close(solution, torch.zeros_like(rhs), rtol=0, atol=0)
     assert info.iterations == 0
     assert info.converged.all()
     assert info.true_relative_residual.max() == 0
+    assert info.tolerance == 0
+
+
+def test_mixed_zero_and_nonzero_rhs_columns_are_supported():
+    matrix = torch.diag(torch.tensor([1.0, 2.0, 4.0], dtype=torch.float64))
+    rhs = torch.stack((torch.zeros(3, dtype=torch.float64), torch.ones(3, dtype=torch.float64)), dim=-1)
+
+    solution, info = linear_cg(matrix, rhs, tolerance=1e-12, return_info=True)
+
+    expected = torch.linalg.solve(matrix, rhs)
+    torch.testing.assert_close(solution, expected, rtol=1e-12, atol=1e-12)
+    torch.testing.assert_close(solution[:, 0], torch.zeros(3, dtype=torch.float64), rtol=0, atol=0)
+    assert info.converged.all()
+
+
+def test_preconditioner_and_breakdown_validation():
+    diagonal = torch.tensor([1.0, 2.0, 4.0], dtype=torch.float64)
+    matrix = torch.diag(diagonal)
+    rhs = torch.ones(3, dtype=torch.float64)
+
+    solution, info = linear_cg(
+        matrix,
+        rhs,
+        preconditioner=lambda value: value / diagonal.unsqueeze(-1),
+        return_info=True,
+    )
+    torch.testing.assert_close(solution, torch.linalg.solve(matrix, rhs), rtol=1e-12, atol=1e-12)
+    assert info.reason == "converged"
+
+    indefinite = torch.diag(torch.tensor([1.0, -1.0, 2.0], dtype=torch.float64))
+    with pytest.raises(RuntimeError, match=r"p\^T A p"):
+        linear_cg(indefinite, torch.tensor([0.0, 1.0, 0.0], dtype=torch.float64))
+
+    with pytest.raises(RuntimeError, match="preconditioned residual inner product"):
+        linear_cg(matrix, rhs, preconditioner=lambda value: -value)
+
+
+def test_user_eps_raises_instead_of_freezing_active_column():
+    matrix = torch.eye(3, dtype=torch.float64)
+    rhs = torch.ones(3, dtype=torch.float64)
+
+    with pytest.raises(RuntimeError, match="at least eps"):
+        linear_cg(
+            matrix,
+            rhs,
+            initial_guess=(1 - 1e-6) * rhs,
+            tolerance=1e-8,
+            eps=1e-10,
+            max_tridiag_iter=0,
+        )
+
+
+def test_stopped_initial_updates_warn_and_report_reason():
+    matrix = torch.eye(3, dtype=torch.float64)
+    rhs = torch.ones(3, dtype=torch.float64)
+
+    with pytest.warns(UserWarning, match="did not converge"):
+        _, info = linear_cg(
+            matrix,
+            rhs,
+            initial_guess=0.5 * rhs,
+            tolerance=0.1,
+            stop_updating_after=0.6,
+            return_info=True,
+        )
+
+    assert info.iterations == 0
+    assert info.reason == "stopped_updating"
+    assert info.tolerance == 0.1
+    assert not info.converged.any()
+
+
+def test_recursive_convergence_is_distinguished_from_true_convergence():
+    calls = 0
+
+    def matmul_with_final_residual_drift(value):
+        nonlocal calls
+        calls += 1
+        return 1.1 * value if calls == 3 else value
+
+    with pytest.warns(UserWarning, match="did not converge"):
+        _, info = linear_cg(
+            matmul_with_final_residual_drift,
+            torch.ones(3, dtype=torch.float64),
+            tolerance=1e-12,
+            max_tridiag_iter=0,
+            return_info=True,
+        )
+
+    assert info.iterations == 1
+    assert info.reason == "recursive_converged"
+    assert info.recursive_relative_residual.max() == 0
+    assert info.true_relative_residual.max() > info.tolerance
+
+
+def test_tridiagonalization_can_return_info():
+    matrix = torch.diag(torch.tensor([1.0, 2.0, 3.0], dtype=torch.float64))
+    rhs = torch.ones(3, dtype=torch.float64)
+
+    solution, tridiagonal, info = linear_cg(
+        matrix,
+        rhs,
+        n_tridiag=1,
+        tolerance=0,
+        max_iter=3,
+        max_tridiag_iter=3,
+        return_info=True,
+    )
+
+    torch.testing.assert_close(solution, torch.linalg.solve(matrix, rhs), rtol=1e-12, atol=1e-12)
+    assert tridiagonal.shape == (1, 3, 3)
+    assert info.iterations == 3
+    assert info.matvecs == 5
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"tolerance": float("nan")}, "tolerance"),
+        ({"tolerance": float("inf")}, "tolerance"),
+        ({"tolerance": -1.0}, "tolerance"),
+        ({"eps": float("nan")}, "eps"),
+        ({"eps": float("inf")}, "eps"),
+        ({"eps": 0.0}, "eps"),
+        ({"stop_updating_after": float("nan")}, "stop_updating_after"),
+        ({"stop_updating_after": float("inf")}, "stop_updating_after"),
+        ({"stop_updating_after": -1.0}, "stop_updating_after"),
+        ({"convergence_reduction": "median"}, "convergence_reduction"),
+        ({"min_iter": -1}, "min_iter"),
+    ],
+)
+def test_invalid_solver_settings_raise(kwargs, match):
+    with pytest.raises(ValueError, match=match):
+        linear_cg(torch.eye(2, dtype=torch.float64), torch.ones(2, dtype=torch.float64), **kwargs)
+
+
+def test_eps_must_be_representable_in_rhs_dtype():
+    with pytest.raises(ValueError, match="representable"):
+        linear_cg(torch.eye(2), torch.ones(2), eps=1e-100)
+
+
+def test_rhs_and_operator_output_validation():
+    matrix = torch.eye(2, dtype=torch.float64)
+    rhs = torch.ones(2, dtype=torch.float64)
+
+    with pytest.raises(TypeError, match="floating-point"):
+        linear_cg(torch.eye(2, dtype=torch.int64), torch.ones(2, dtype=torch.int64))
+    with pytest.raises(RuntimeError, match="matmul_closure output"):
+        linear_cg(lambda value: value[:-1], rhs)
+    with pytest.raises(RuntimeError, match="preconditioner output"):
+        linear_cg(matrix, rhs, preconditioner=lambda value: value.to(torch.float32))
 
 
 def test_vector_rank_is_preserved_with_vector_initial_guess():

--- a/torchsparsegradutils/utils/__init__.py
+++ b/torchsparsegradutils/utils/__init__.py
@@ -1,6 +1,6 @@
 from .bicgstab import BICGSTABSettings, bicgstab
 from .dist_stats_helpers import cov_nagao_test, mean_hotelling_t2_test
-from .linear_cg import LinearCGSettings, linear_cg
+from .linear_cg import CGInfo, LinearCGSettings, linear_cg
 from .lsmr import lsmr
 from .minres import MINRESSettings, minres
 from .random_sparse import rand_sparse, rand_sparse_tri
@@ -16,6 +16,7 @@ from .utils import (
 __all__ = [
     "linear_cg",
     "LinearCGSettings",
+    "CGInfo",
     "minres",
     "MINRESSettings",
     "bicgstab",

--- a/torchsparsegradutils/utils/linear_cg.py
+++ b/torchsparsegradutils/utils/linear_cg.py
@@ -2,7 +2,9 @@
 # Minor modifications for torchsparsegradutils to remove dependencies
 
 import warnings
-from typing import Callable, NamedTuple, Optional, Union
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import NamedTuple
 
 import torch
 
@@ -15,13 +17,32 @@ class LinearCGSettings(NamedTuple):
     )
     # Lanczos quadrature. This is ONLY used for log determinant calculations and
     # computing Tr(K^{-1}dK/d\theta)
-    cg_tolerance: float = 1  # Relative residual tolerance to use for terminating CG.
+    cg_tolerance: float = 1e-5  # Relative residual tolerance to use for terminating CG.
     terminate_cg_by_size: bool = False  # If set to true, cg will terminate after n iterations for an n x n matrix.
     verbose_linalg: bool = False  # Print out information whenever running an expensive linear algebra routine
 
 
+_DEFAULT_LINEAR_CG_SETTINGS = LinearCGSettings()
+
+
 def _default_preconditioner(x):
     return x.clone()
+
+
+@dataclass(frozen=True)
+class CGInfo:
+    """Convergence information returned by linear_cg.
+
+    Residual tensors have shape (batch_shape, num_rhs). Vector right-hand
+    sides therefore produce a length-one residual tensor.
+    """
+
+    iterations: int
+    matvecs: int
+    converged: torch.Tensor
+    recursive_relative_residual: torch.Tensor
+    true_relative_residual: torch.Tensor
+    reason: str
 
 
 def _linear_cg_updates(
@@ -64,6 +85,10 @@ def _linear_cg_updates_no_precond(
     torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
     torch.sum(mul_storage, dim=-2, keepdim=True, out=alpha)
 
+    active = ~has_converged
+    if bool((active & ((alpha <= 0) | ~torch.isfinite(alpha))).any()):
+        raise RuntimeError("CG breakdown: p^T A p must be finite and positive for active right-hand sides")
+
     # Do a safe division here
     torch.lt(alpha, eps, out=is_zero)
     alpha.masked_fill_(is_zero, 1)
@@ -95,19 +120,27 @@ def _linear_cg_updates_no_precond(
     )
 
 
-def linear_cg(
-    matmul_closure: Union[torch.Tensor, Callable[[torch.Tensor], torch.Tensor]],
+def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one recurrence
+    matmul_closure: torch.Tensor | Callable[[torch.Tensor], torch.Tensor],
     rhs: torch.Tensor,
     n_tridiag: int = 0,
-    tolerance: Optional[float] = None,
-    eps: float = 1e-10,
-    stop_updating_after: float = 1e-10,
-    max_iter: Optional[int] = None,
-    max_tridiag_iter: Optional[int] = None,
-    initial_guess: Optional[torch.Tensor] = None,
-    preconditioner: Optional[Callable[[torch.Tensor], torch.Tensor]] = None,
-    settings: LinearCGSettings = LinearCGSettings(),
-) -> Union[torch.Tensor, tuple[torch.Tensor, torch.Tensor]]:
+    tolerance: float | None = None,
+    eps: float | None = None,
+    stop_updating_after: float | None = None,
+    max_iter: int | None = None,
+    max_tridiag_iter: int | None = None,
+    initial_guess: torch.Tensor | None = None,
+    preconditioner: Callable[[torch.Tensor], torch.Tensor] | None = None,
+    settings: LinearCGSettings = _DEFAULT_LINEAR_CG_SETTINGS,
+    convergence_reduction: str = "all",
+    min_iter: int = 0,
+    return_info: bool = False,
+) -> (
+    torch.Tensor
+    | tuple[torch.Tensor, torch.Tensor]
+    | tuple[torch.Tensor, CGInfo]
+    | tuple[torch.Tensor, torch.Tensor, CGInfo]
+):
     r"""
     Solve symmetric positive definite linear systems using conjugate gradient (CG).
 
@@ -126,12 +159,15 @@ def linear_cg(
         Number of Lanczos tridiagonalizations (probe vectors). If ``> 0``,
         tridiagonal matrices are returned in addition to the solution. Default: ``0``.
     tolerance : float, optional
-        Average residual-norm stopping criterion. If ``None``, uses
+        Relative residual-norm stopping criterion. If ``None``, uses
         ``settings.cg_tolerance``.
     eps : float, optional
-        Small constant to avoid division by zero. Default: ``1e-10``.
+        Absolute breakdown threshold for recurrence denominators. If ``None``,
+        uses the smallest positive normal value of the RHS dtype. The historical
+        fixed default of 1e-10 can stall accurate solves.
     stop_updating_after : float, optional
-        Per-vector early-stop threshold for residual norms. Default: ``1e-10``.
+        Per-vector early-stop threshold for normalized residual norms. If
+        ``None``, uses ``tolerance``.
     max_iter : int, optional
         Maximum CG iterations. If ``None``, uses ``settings.max_cg_iterations``.
     max_tridiag_iter : int, optional
@@ -144,14 +180,23 @@ def linear_cg(
         If ``None``, no preconditioning is used.
     settings : LinearCGSettings, optional
         Configuration for iteration caps, tolerances, and logging verbosity.
+    convergence_reduction : {"all", "mean"}, optional
+        Stop when every right-hand side passes tolerance (default), or retain
+        the historical mean-residual behavior.
+    min_iter : int, optional
+        Minimum number of iterations before tolerance termination. Default: 0.
+    return_info : bool, optional
+        Return ``CGInfo`` containing recomputed true relative residuals,
+        per-right-hand-side convergence, iterations, and matvecs.
 
     Returns
     -------
-    torch.Tensor or (torch.Tensor, torch.Tensor)
+    torch.Tensor or tuple
         * If ``n_tridiag == 0``: solution ``x`` with the same shape as ``rhs``.
         * If ``n_tridiag > 0``: ``(x, T)`` where ``T`` has shape
           ``(n_tridiag, *rhs.shape[:-2], r, r)`` with ``r = last_tridiag_iter + 1``
           and ``r <= min(max_tridiag_iter, n)``. Without batch dims this is ``(n_tridiag, r, r)``.
+        * If ``return_info`` is true, append a ``CGInfo`` object.
 
     Raises
     ------
@@ -210,10 +255,16 @@ def linear_cg(
     ----------
     .. [1e] linear_operator library. https://github.com/cornellius-gp/linear_operator
     """
-    # Unsqueeze, if necessary
+    if not isinstance(rhs, torch.Tensor) or not torch.is_floating_point(rhs):
+        raise TypeError("rhs must be a real floating-point torch.Tensor")
+    if rhs.ndimension() not in (1, 2, 3):
+        raise ValueError("rhs must be a vector, matrix, or batched matrix")
+
+    # Unsqueeze vector right-hand sides without later reusing this rank flag.
     is_vector = rhs.ndimension() == 1
     if is_vector:
         rhs = rhs.unsqueeze(-1)
+    rhs_original = rhs
 
     # Some default arguments
     if max_iter is None:
@@ -223,12 +274,28 @@ def linear_cg(
     if initial_guess is None:
         initial_guess = torch.zeros_like(rhs)
     else:
-        # Unsqueeze, if necessary
-        is_vector = initial_guess.ndimension() == 1
-        if is_vector:
+        if initial_guess.ndimension() == 1:
             initial_guess = initial_guess.unsqueeze(-1)
+        if initial_guess.shape != rhs.shape:
+            raise ValueError(f"initial_guess must have shape {tuple(rhs.shape)}, got {tuple(initial_guess.shape)}")
+        if initial_guess.device != rhs.device or initial_guess.dtype != rhs.dtype:
+            raise ValueError("initial_guess must share rhs device and dtype")
     if tolerance is None:
         tolerance = settings.cg_tolerance
+    if tolerance < 0:
+        raise ValueError("tolerance must be nonnegative")
+    if eps is None:
+        eps = torch.finfo(rhs.dtype).tiny
+    if eps <= 0:
+        raise ValueError("eps must be positive")
+    if stop_updating_after is None:
+        stop_updating_after = tolerance
+    if stop_updating_after < 0:
+        raise ValueError("stop_updating_after must be nonnegative")
+    if convergence_reduction not in ("all", "mean"):
+        raise ValueError("convergence_reduction must be 'all' or 'mean'")
+    if min_iter < 0:
+        raise ValueError("min_iter must be nonnegative")
     if preconditioner is None:
         preconditioner = _default_preconditioner
         precond = False
@@ -249,21 +316,27 @@ def linear_cg(
     num_rows = rhs.size(-2)
     n_iter = min(max_iter, num_rows) if settings.terminate_cg_by_size else max_iter
     n_tridiag_iter = min(max_tridiag_iter, num_rows)
-    eps = torch.tensor(eps, dtype=rhs.dtype, device=rhs.device)
+    eps_tensor = torch.tensor(eps, dtype=rhs.dtype, device=rhs.device)
 
     # Get the norm of the rhs - used for convergence checks
     # Here we're going to make almost-zero norms actually be 1 (so we don't get divide-by-zero issues)
     # But we'll store which norms were actually close to zero
     rhs_norm = torch.linalg.vector_norm(rhs, ord=2, dim=-2, keepdim=True)
-    rhs_is_zero = rhs_norm.lt(eps)
+    rhs_is_zero = rhs_norm.eq(0)
     rhs_norm = rhs_norm.masked_fill_(rhs_is_zero, 1)
 
     # Let's normalize. We'll un-normalize afterwards
     rhs = rhs.div(rhs_norm)
     initial_guess = initial_guess.div(rhs_norm)
+    # The unique solution of an SPD zero-RHS system is zero. Do not return an
+    # arbitrary nonzero initial guess while marking that column converged.
+    initial_guess = initial_guess.masked_fill(rhs_is_zero, 0)
 
     # residual: residual_{0} = b_vec - lhs x_{0}
     residual = rhs - matmul_closure(initial_guess)
+    matvecs = 1
+    if residual.shape != rhs.shape or residual.device != rhs.device or residual.dtype != rhs.dtype:
+        raise RuntimeError("matmul_closure output must match rhs shape, device, and dtype")
     batch_shape = residual.shape[:-2]
 
     # result <- x_{0}
@@ -290,8 +363,17 @@ def linear_cg(
     else:
         # precon_residual{0} = M^-1 residual_{0}
         precond_residual = preconditioner(residual)
+        if (
+            precond_residual.shape != residual.shape
+            or precond_residual.device != residual.device
+            or precond_residual.dtype != residual.dtype
+        ):
+            raise RuntimeError("preconditioner output must match residual shape, device, and dtype")
         curr_conjugate_vec = precond_residual
         residual_inner_prod = precond_residual.mul(residual).sum(-2, keepdim=True)
+        active = ~has_converged
+        if bool((active & ((residual_inner_prod <= 0) | ~torch.isfinite(residual_inner_prod))).any()):
+            raise RuntimeError("CG breakdown: preconditioned residual inner product must be finite and positive")
 
         # Define storage matrices
         mul_storage = torch.empty_like(residual)
@@ -314,18 +396,26 @@ def linear_cg(
 
     # It's conceivable we reach the tolerance on the last iteration, so can't just check iteration number.
     tolerance_reached = False
+    iterations = 0
 
     # Start the iteration
     for k in range(n_iter):
         # Get next alpha
         # alpha_{k} = (residual_{k-1}^T precon_residual{k-1}) / (p_vec_{k-1}^T mat p_vec_{k-1})
         mvms = matmul_closure(curr_conjugate_vec)
+        matvecs += 1
+        if mvms.shape != rhs.shape or mvms.device != rhs.device or mvms.dtype != rhs.dtype:
+            raise RuntimeError("matmul_closure output must match rhs shape, device, and dtype")
         if precond:
             torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
             torch.sum(mul_storage, -2, keepdim=True, out=alpha)
 
+            active = ~has_converged
+            if bool((active & ((alpha <= 0) | ~torch.isfinite(alpha))).any()):
+                raise RuntimeError("CG breakdown: p^T A p must be finite and positive for active right-hand sides")
+
             # Do a safe division here
-            torch.lt(alpha, eps, out=is_zero)
+            torch.lt(alpha, eps_tensor, out=is_zero)
             alpha.masked_fill_(is_zero, 1)
             torch.div(residual_inner_prod, alpha, out=alpha)
             alpha.masked_fill_(is_zero, 0)
@@ -340,12 +430,18 @@ def linear_cg(
             # Update precond_residual
             # precon_residual{k} = M^-1 residual_{k}
             precond_residual = preconditioner(residual)
+            if (
+                precond_residual.shape != residual.shape
+                or precond_residual.device != residual.device
+                or precond_residual.dtype != residual.dtype
+            ):
+                raise RuntimeError("preconditioner output must match residual shape, device, and dtype")
 
             _linear_cg_updates(
                 result,
                 alpha,
                 residual_inner_prod,
-                eps,
+                eps_tensor,
                 beta,
                 residual,
                 precond_residual,
@@ -360,7 +456,7 @@ def linear_cg(
                 has_converged,
                 alpha,
                 residual_inner_prod,
-                eps,
+                eps_tensor,
                 beta,
                 residual,
                 precond_residual,
@@ -370,14 +466,15 @@ def linear_cg(
             )
 
         torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True, out=residual_norm)
-        residual_norm.masked_fill_(rhs_is_zero, 0)
         torch.lt(residual_norm, stop_updating_after, out=has_converged)
+        iterations = k + 1
 
-        if (
-            k >= min(10, max_iter - 1)
-            and bool(residual_norm.mean() < tolerance)
-            and not (n_tridiag and k < min(n_tridiag_iter, max_iter - 1))
-        ):
+        if convergence_reduction == "all":
+            convergence_reached = bool(torch.le(residual_norm, tolerance).all())
+        else:
+            convergence_reached = bool(residual_norm.mean() <= tolerance)
+
+        if iterations >= min_iter and convergence_reached and not (n_tridiag and k < min(n_tridiag_iter, max_iter - 1)):
             tolerance_reached = True
             break
 
@@ -405,26 +502,52 @@ def linear_cg(
             prev_alpha_reciprocal.copy_(alpha_reciprocal)
             prev_beta.copy_(beta_tridiag)
 
-    # Un-normalize
+    # Un-normalize and recompute a true residual before reporting convergence.
     result = result.mul(rhs_norm)
+    true_residual = rhs_original - matmul_closure(result)
+    matvecs += 1
+    if true_residual.shape != rhs.shape or true_residual.device != rhs.device or true_residual.dtype != rhs.dtype:
+        raise RuntimeError("matmul_closure output must match rhs shape, device, and dtype")
+    rhs_original_norm = torch.linalg.vector_norm(rhs_original, ord=2, dim=-2, keepdim=True)
+    denominator = rhs_original_norm.masked_fill(rhs_original_norm.eq(0), 1)
+    true_relative_residual = torch.linalg.vector_norm(true_residual, ord=2, dim=-2, keepdim=True) / denominator
+    recursive_relative_residual = residual_norm
+    converged = torch.le(true_relative_residual, tolerance)
+    all_true_converged = bool(converged.all())
+    if all_true_converged:
+        reason = "converged"
+    elif tolerance_reached and convergence_reduction == "mean":
+        reason = "mean_converged"
+    else:
+        reason = "max_iter"
 
-    if not tolerance_reached and n_iter > 0:
+    if tolerance > 0 and not all_true_converged and n_iter > 0:
         warnings.warn(
-            "CG terminated in {} iterations with average residual norm {}"
-            " which is larger than the tolerance of {} specified by"
-            " linear_operator.settings.cg_tolerance."
-            " If performance is affected, consider raising the maximum number of CG iterations by running code in"
-            " a linear_operator.settings.max_cg_iterations(value) context.".format(
-                k + 1, residual_norm.mean(), tolerance
-            ),
+            f"CG terminated in {iterations} iterations with maximum true relative residual "
+            f"{true_relative_residual.max()} which is larger than the tolerance of {tolerance}. "
+            f"{(~converged).sum()} of {converged.numel()} right-hand sides did not converge.",
             UserWarning,
+            stacklevel=2,
         )
+
+    info = CGInfo(
+        iterations=iterations,
+        matvecs=matvecs,
+        converged=converged.squeeze(-2).detach(),
+        recursive_relative_residual=recursive_relative_residual.squeeze(-2).detach(),
+        true_relative_residual=true_relative_residual.squeeze(-2).detach(),
+        reason=reason,
+    )
 
     if is_vector:
         result = result.squeeze(-1)
 
     if n_tridiag:
         t_mat = t_mat[: last_tridiag_iter + 1, : last_tridiag_iter + 1]
-        return result, t_mat.permute(-1, *range(2, 2 + len(batch_shape)), 0, 1).contiguous()
-    else:
-        return result
+        tridiagonal = t_mat.permute(-1, *range(2, 2 + len(batch_shape)), 0, 1).contiguous()
+        if return_info:
+            return result, tridiagonal, info
+        return result, tridiagonal
+    if return_info:
+        return result, info
+    return result

--- a/torchsparsegradutils/utils/linear_cg.py
+++ b/torchsparsegradutils/utils/linear_cg.py
@@ -355,7 +355,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     residual_norm = torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True)
     has_converged = torch.lt(residual_norm, stop_updating_after)
 
-    if has_converged.all() and not n_tridiag:
+    if has_converged.all() and not n_tridiag and min_iter == 0:
         n_iter = 0  # Skip the iteration!
 
     # Otherwise, let's define precond_residual and curr_conjugate_vec

--- a/torchsparsegradutils/utils/linear_cg.py
+++ b/torchsparsegradutils/utils/linear_cg.py
@@ -257,8 +257,8 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     """
     if not isinstance(rhs, torch.Tensor) or not torch.is_floating_point(rhs):
         raise TypeError("rhs must be a real floating-point torch.Tensor")
-    if rhs.ndimension() not in (1, 2, 3):
-        raise ValueError("rhs must be a vector, matrix, or batched matrix")
+    if rhs.ndimension() < 1:
+        raise ValueError("rhs must have at least one dimension")
 
     # Unsqueeze vector right-hand sides without later reusing this rank flag.
     is_vector = rhs.ndimension() == 1
@@ -318,9 +318,8 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     n_tridiag_iter = min(max_tridiag_iter, num_rows)
     eps_tensor = torch.tensor(eps, dtype=rhs.dtype, device=rhs.device)
 
-    # Get the norm of the rhs - used for convergence checks
-    # Here we're going to make almost-zero norms actually be 1 (so we don't get divide-by-zero issues)
-    # But we'll store which norms were actually close to zero
+    # Get the norm of the rhs for convergence checks. Replace exact-zero
+    # norms with 1 to avoid division by zero, while tracking those RHS columns.
     rhs_norm = torch.linalg.vector_norm(rhs, ord=2, dim=-2, keepdim=True)
     rhs_is_zero = rhs_norm.eq(0)
     rhs_norm = rhs_norm.masked_fill_(rhs_is_zero, 1)
@@ -522,10 +521,12 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
         reason = "max_iter"
 
     if tolerance > 0 and not all_true_converged and n_iter > 0:
+        maximum_residual = true_relative_residual.max().item()
+        num_unconverged = (~converged).sum().item()
         warnings.warn(
             f"CG terminated in {iterations} iterations with maximum true relative residual "
-            f"{true_relative_residual.max()} which is larger than the tolerance of {tolerance}. "
-            f"{(~converged).sum()} of {converged.numel()} right-hand sides did not converge.",
+            f"{maximum_residual} which is larger than the tolerance of {tolerance}. "
+            f"{num_unconverged} of {converged.numel()} right-hand sides did not converge.",
             UserWarning,
             stacklevel=2,
         )

--- a/torchsparsegradutils/utils/linear_cg.py
+++ b/torchsparsegradutils/utils/linear_cg.py
@@ -1,10 +1,11 @@
 # MIT-licensed code imported from https://github.com/cornellius-gp/linear_operator
 # Minor modifications for torchsparsegradutils to remove dependencies
 
+import math
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import torch
 
@@ -33,8 +34,14 @@ def _default_preconditioner(x):
 class CGInfo:
     """Convergence information returned by linear_cg.
 
-    Residual tensors have shape (batch_shape, num_rhs). Vector right-hand
+    Residual tensors have shape (*batch_shape, num_rhs). Vector right-hand
     sides therefore produce a length-one residual tensor.
+
+    The reason is "converged" when the recomputed true residual meets
+    tolerance, "recursive_converged" or "mean_converged" when an internal
+    stopping criterion is met but the true residual is not, "stopped_updating"
+    when the initial residual is below stop_updating_after but not tolerance,
+    and "max_iter" when the iteration limit is reached.
     """
 
     iterations: int
@@ -42,7 +49,29 @@ class CGInfo:
     converged: torch.Tensor
     recursive_relative_residual: torch.Tensor
     true_relative_residual: torch.Tensor
-    reason: str
+    tolerance: float
+    reason: Literal["converged", "recursive_converged", "mean_converged", "stopped_updating", "max_iter"]
+
+
+def _validate_recurrence_denominators(
+    curvature: torch.Tensor,
+    residual_inner_prod: torch.Tensor,
+    eps: torch.Tensor,
+    has_converged: torch.Tensor,
+) -> None:
+    """Reject invalid active recurrence denominators with one device sync."""
+    active = ~has_converged
+    invalid_curvature = active & ((curvature < eps) | ~torch.isfinite(curvature))
+    invalid_inner_product = active & ((residual_inner_prod < eps) | ~torch.isfinite(residual_inner_prod))
+    curvature_failed, inner_product_failed = torch.stack(
+        (invalid_curvature.any(), invalid_inner_product.any())
+    ).tolist()
+    if curvature_failed:
+        raise RuntimeError("CG breakdown: p^T A p must be finite and at least eps for active right-hand sides")
+    if inner_product_failed:
+        raise RuntimeError(
+            "CG breakdown: residual inner product must be finite and at least eps for active right-hand sides"
+        )
 
 
 def _linear_cg_updates(
@@ -85,9 +114,7 @@ def _linear_cg_updates_no_precond(
     torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
     torch.sum(mul_storage, dim=-2, keepdim=True, out=alpha)
 
-    active = ~has_converged
-    if bool((active & ((alpha <= 0) | ~torch.isfinite(alpha))).any()):
-        raise RuntimeError("CG breakdown: p^T A p must be finite and positive for active right-hand sides")
+    _validate_recurrence_denominators(alpha, residual_inner_prod, eps, has_converged)
 
     # Do a safe division here
     torch.lt(alpha, eps, out=is_zero)
@@ -132,7 +159,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     initial_guess: torch.Tensor | None = None,
     preconditioner: Callable[[torch.Tensor], torch.Tensor] | None = None,
     settings: LinearCGSettings = _DEFAULT_LINEAR_CG_SETTINGS,
-    convergence_reduction: str = "all",
+    convergence_reduction: Literal["all", "mean"] = "all",
     min_iter: int = 0,
     return_info: bool = False,
 ) -> (
@@ -159,15 +186,16 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
         Number of Lanczos tridiagonalizations (probe vectors). If ``> 0``,
         tridiagonal matrices are returned in addition to the solution. Default: ``0``.
     tolerance : float, optional
-        Relative residual-norm stopping criterion. If ``None``, uses
-        ``settings.cg_tolerance``.
+        Finite, nonnegative relative residual-norm stopping criterion. If
+        ``None``, uses ``settings.cg_tolerance``.
     eps : float, optional
-        Absolute breakdown threshold for recurrence denominators. If ``None``,
-        uses the smallest positive normal value of the RHS dtype. The historical
-        fixed default of 1e-10 can stall accurate solves.
+        Finite, positive breakdown threshold for recurrence denominators.
+        Active denominators below this threshold raise ``RuntimeError`` rather
+        than silently freezing an unconverged column. If ``None``, uses the
+        smallest positive normal value of the RHS dtype.
     stop_updating_after : float, optional
-        Per-vector early-stop threshold for normalized residual norms. If
-        ``None``, uses ``tolerance``.
+        Finite, nonnegative per-vector early-stop threshold for normalized
+        residual norms. If ``None``, uses ``tolerance``.
     max_iter : int, optional
         Maximum CG iterations. If ``None``, uses ``settings.max_cg_iterations``.
     max_tridiag_iter : int, optional
@@ -187,7 +215,8 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
         Minimum number of iterations before tolerance termination. Default: 0.
     return_info : bool, optional
         Return ``CGInfo`` containing recomputed true relative residuals,
-        per-right-hand-side convergence, iterations, and matvecs.
+        the requested tolerance, per-right-hand-side convergence, iterations,
+        matvecs, and termination reason.
 
     Returns
     -------
@@ -200,10 +229,14 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
 
     Raises
     ------
+    TypeError
+        If ``rhs`` is not a real floating-point tensor.
+    ValueError
+        If tensor shapes, devices, or dtypes are incompatible, or if a solver
+        setting is invalid.
     RuntimeError
-        If ``max_tridiag_iter > max_iter``.
-    RuntimeError
-        If ``matmul_closure`` is neither a tensor nor a callable.
+        If Lanczos settings are incompatible, an operator returns an invalid
+        tensor, or an active CG recurrence denominator breaks down.
 
     Notes
     -----
@@ -229,7 +262,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     Multiple RHS::
 
         >>> B = torch.randn(2, 5)  # 5 RHS
-        >>> X = linear_cg(A.matmul, B, max_iter=100, tolerance=1e-8)
+        >>> X = linear_cg(A.matmul, B, max_iter=100, tolerance=1e-5)
         >>> X.shape
         torch.Size([2, 5])
 
@@ -260,7 +293,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     if rhs.ndimension() < 1:
         raise ValueError("rhs must have at least one dimension")
 
-    # Unsqueeze vector right-hand sides without later reusing this rank flag.
+    # Temporarily add a column dimension for vector right-hand sides.
     is_vector = rhs.ndimension() == 1
     if is_vector:
         rhs = rhs.unsqueeze(-1)
@@ -282,16 +315,16 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
             raise ValueError("initial_guess must share rhs device and dtype")
     if tolerance is None:
         tolerance = settings.cg_tolerance
-    if tolerance < 0:
-        raise ValueError("tolerance must be nonnegative")
+    if not math.isfinite(tolerance) or tolerance < 0:
+        raise ValueError("tolerance must be finite and nonnegative")
     if eps is None:
         eps = torch.finfo(rhs.dtype).tiny
-    if eps <= 0:
-        raise ValueError("eps must be positive")
+    if not math.isfinite(eps) or eps <= 0:
+        raise ValueError("eps must be finite and positive")
     if stop_updating_after is None:
         stop_updating_after = tolerance
-    if stop_updating_after < 0:
-        raise ValueError("stop_updating_after must be nonnegative")
+    if not math.isfinite(stop_updating_after) or stop_updating_after < 0:
+        raise ValueError("stop_updating_after must be finite and nonnegative")
     if convergence_reduction not in ("all", "mean"):
         raise ValueError("convergence_reduction must be 'all' or 'mean'")
     if min_iter < 0:
@@ -317,6 +350,8 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     n_iter = min(max_iter, num_rows) if settings.terminate_cg_by_size else max_iter
     n_tridiag_iter = min(max_tridiag_iter, num_rows)
     eps_tensor = torch.tensor(eps, dtype=rhs.dtype, device=rhs.device)
+    if not bool(eps_tensor > 0):
+        raise ValueError("eps must be representable as a positive value in the rhs dtype")
 
     # Get the norm of the rhs for convergence checks. Replace exact-zero
     # norms with 1 to avoid division by zero, while tracking those RHS columns.
@@ -353,10 +388,12 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     # Sometime we're lucky and the preconditioner solves the system right away
     # Check for convergence
     residual_norm = torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True)
-    has_converged = torch.lt(residual_norm, stop_updating_after)
+    has_converged = torch.le(residual_norm, stop_updating_after)
+    stopped_before_iteration = False
 
     if has_converged.all() and not n_tridiag and min_iter == 0:
         n_iter = 0  # Skip the iteration!
+        stopped_before_iteration = True
 
     # Otherwise, let's define precond_residual and curr_conjugate_vec
     else:
@@ -371,8 +408,8 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
         curr_conjugate_vec = precond_residual
         residual_inner_prod = precond_residual.mul(residual).sum(-2, keepdim=True)
         active = ~has_converged
-        if bool((active & ((residual_inner_prod <= 0) | ~torch.isfinite(residual_inner_prod))).any()):
-            raise RuntimeError("CG breakdown: preconditioned residual inner product must be finite and positive")
+        if bool((active & ((residual_inner_prod < eps_tensor) | ~torch.isfinite(residual_inner_prod))).any()):
+            raise RuntimeError("CG breakdown: preconditioned residual inner product must be finite and at least eps")
 
         # Define storage matrices
         mul_storage = torch.empty_like(residual)
@@ -409,9 +446,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
             torch.mul(curr_conjugate_vec, mvms, out=mul_storage)
             torch.sum(mul_storage, -2, keepdim=True, out=alpha)
 
-            active = ~has_converged
-            if bool((active & ((alpha <= 0) | ~torch.isfinite(alpha))).any()):
-                raise RuntimeError("CG breakdown: p^T A p must be finite and positive for active right-hand sides")
+            _validate_recurrence_denominators(alpha, residual_inner_prod, eps_tensor, has_converged)
 
             # Do a safe division here
             torch.lt(alpha, eps_tensor, out=is_zero)
@@ -465,7 +500,7 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
             )
 
         torch.linalg.vector_norm(residual, ord=2, dim=-2, keepdim=True, out=residual_norm)
-        torch.lt(residual_norm, stop_updating_after, out=has_converged)
+        torch.le(residual_norm, stop_updating_after, out=has_converged)
         iterations = k + 1
 
         if convergence_reduction == "all":
@@ -515,12 +550,14 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
     all_true_converged = bool(converged.all())
     if all_true_converged:
         reason = "converged"
-    elif tolerance_reached and convergence_reduction == "mean":
-        reason = "mean_converged"
+    elif tolerance_reached:
+        reason = "mean_converged" if convergence_reduction == "mean" else "recursive_converged"
+    elif stopped_before_iteration:
+        reason = "stopped_updating"
     else:
         reason = "max_iter"
 
-    if tolerance > 0 and not all_true_converged and n_iter > 0:
+    if not all_true_converged:
         maximum_residual = true_relative_residual.max().item()
         num_unconverged = (~converged).sum().item()
         warnings.warn(
@@ -531,14 +568,16 @@ def linear_cg(  # noqa: C901 - inherited solver is intentionally kept as one rec
             stacklevel=2,
         )
 
-    info = CGInfo(
-        iterations=iterations,
-        matvecs=matvecs,
-        converged=converged.squeeze(-2).detach(),
-        recursive_relative_residual=recursive_relative_residual.squeeze(-2).detach(),
-        true_relative_residual=true_relative_residual.squeeze(-2).detach(),
-        reason=reason,
-    )
+    if return_info:
+        info = CGInfo(
+            iterations=iterations,
+            matvecs=matvecs,
+            converged=converged.squeeze(-2).detach(),
+            recursive_relative_residual=recursive_relative_residual.squeeze(-2).detach(),
+            true_relative_residual=true_relative_residual.squeeze(-2).detach(),
+            tolerance=tolerance,
+            reason=reason,
+        )
 
     if is_vector:
         result = result.squeeze(-1)


### PR DESCRIPTION
## Problem statement

I have been working on some side projects using TSGU and have had consistent issues with the CG algorithm as implemented. In particular, solves can stop without every right-hand side meeting the requested tolerance, tight float64 solves can stall because a fixed absolute `1e-10` threshold suppresses valid late updates, and the solver reports only its recursively updated residual rather than checking the true residual `b - A @ x` before returning.

This makes it difficult for callers to distinguish a genuinely converged solve from an inaccurate result, especially for batched or multiple-right-hand-side systems.

## What this PR changes

- use per-right-hand-side relative convergence by default, while retaining the historical mean reduction as an explicit compatibility mode
- replace the fixed recurrence epsilon with a dtype-aware default and handle exact zero right-hand sides correctly
- recompute the true residual before returning and expose iterations, matvecs, per-RHS convergence, residuals, and termination reason through opt-in `CGInfo`
- validate solver inputs and detect non-positive or non-finite active curvature instead of silently applying invalid updates
- add a reproducible old-versus-new numerical benchmark

## Compatibility notes

- `LinearCGSettings.cg_tolerance` now defaults to `1e-5` instead of `1`, so callers relying on default settings receive a meaningful relative-accuracy target.
- The historical forced minimum of roughly ten iterations is removed. Convergence may terminate immediately by default; callers that need an iteration floor can set `min_iter`.
- Per-RHS `"all"` convergence is now the default. The historical mean-residual criterion remains available with `convergence_reduction="mean"`.

The PR focuses on convergence semantics, the fixed-epsilon stall, and trustworthy final diagnostics. Periodic reliable-update restarts and FP64 scalar reductions remain possible follow-up work for especially ill-conditioned low-precision systems.

## Numerical evidence

The comparison command was:

```bash
python -m torchsparsegradutils.benchmarks.linear_cg_convergence \
  --baseline-ref ea7b8f0 --device cuda:0 --warmup 10 --repeats 100
```

Environment: NVIDIA GeForce RTX 4090, PyTorch 2.13.0+cu130, float64 benchmark systems.

| Case | Historical solver | Fixed solver | Effect |
|---|---:|---:|---|
| Tight tolerance (`tol=1e-12`) | 200 iterations, true residual `5.94e-6`, 16.78 ms | 14 iterations, true residual `4.02e-13`, 1.89 ms | Removes the historical absolute-epsilon stall and meets tolerance |
| 101 RHS, one hard column (`tol=1e-4`) | 19 iterations, worst residual `9.46e-3`, 1 unconverged RHS | 27 iterations, worst residual `5.44e-5`, 0 unconverged RHS | Prevents easy columns from hiding one inaccurate solve; extra work is required for correctness |
| Zero RHS with nonzero initial guess | 11 iterations, residual `9.06e-1` | 0 iterations, exact zero residual | Returns the unique zero solution immediately |

CPU results reproduce the same residuals and iteration counts.

The benchmark deliberately checks the recomputed true residual rather than trusting the internal recurrence residual. The fixed solver also returns these diagnostics directly through `CGInfo`, allowing downstream callers to reject inaccurate solves explicitly.

## Validation

- `python -m black --check .`
- `python -m isort --check-only --diff .`
- `python -m flake8 . --count --show-source --statistics`
- `python -m pytest -q` — 2,618 passed, 542 skipped
- `python -m build` — sdist and wheel built successfully

@tvercaut, could you review the numerical scope and API changes?